### PR TITLE
fix(clipboard): bound channels and coalesce ui notifications

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,17 +31,35 @@ use crate::{
 #[cfg(target_os = "linux")]
 pub static X11_INSTANCE: OnceLock<X11> = OnceLock::new();
 
+/// Capacity for the clipboard event channel between the OS clipboard listener
+/// and the persistence task. Large enough to absorb bursts from apps that copy
+/// several times per second, while preventing unbounded memory growth if the
+/// consumer falls behind. When full, new events are dropped and logged.
+const CLIPBOARD_EVENT_CHANNEL_CAPACITY: usize = 256;
+
+/// Capacity for the UI refresh notification channel. Notifications carry no
+/// payload — the foreground task coalesces all pending notifications into a
+/// single repository read + UI refresh, so a small bounded capacity is
+/// sufficient. When full, additional notifications are no-ops because a
+/// refresh is already pending.
+const UI_NOTIFY_CHANNEL_CAPACITY: usize = 256;
+
 /// Consume clipboard events from the monitor, persist them to the repository,
 /// update the in-memory record list, and notify the GUI to refresh.
 ///
 /// This coordinates across three subsystems (clipboard, repository, GUI)
 /// and does not belong to the clipboard I/O layer alone.
+///
+/// The notification channel is bounded and notifications are coalesced: the
+/// foreground task drains all pending `()` notifications before doing a single
+/// repository read + UI refresh. This avoids redundant full-list refreshes
+/// when many records arrive in rapid succession.
 fn start_clipboard_event_handler(
     clipboard_rx: async_channel::Receiver<ClipboardEvent>,
     window_handle: WindowHandle<Root>,
     cx: &App,
 ) {
-    let (notify_tx, notify_rx) = async_channel::unbounded::<()>();
+    let (notify_tx, notify_rx) = async_channel::bounded::<()>(UI_NOTIFY_CHANNEL_CAPACITY);
 
     // Clone the Arc before moving into the background task, since GPUI
     // globals are not accessible from background threads.
@@ -64,8 +82,19 @@ fn start_clipboard_event_handler(
 
             match result {
                 Ok(_record) => {
-                    if let Err(e) = notify_tx.send(()).await {
-                        tracing::warn!(error = %e, "failed to notify foreground of new record");
+                    // Use try_send: if the channel is already full a refresh
+                    // is already pending, so dropping this notification is
+                    // equivalent to coalescing it with the queued one.
+                    match notify_tx.try_send(()) {
+                        Ok(()) => {}
+                        Err(async_channel::TrySendError::Full(())) => {
+                            tracing::debug!("ui refresh notification coalesced (channel full)");
+                        }
+                        Err(async_channel::TrySendError::Closed(())) => {
+                            tracing::warn!(
+                                "ui refresh notification channel closed; foreground task gone"
+                            );
+                        }
                     }
                 }
                 Err(e) => {
@@ -79,6 +108,10 @@ fn start_clipboard_event_handler(
     // Process saved records on the foreground thread where GPUI globals are accessible.
     cx.spawn(async move |async_app| {
         while notify_rx.recv().await.is_ok() {
+            // Coalesce: drain all additional pending notifications so a burst
+            // of saves results in a single repository read + UI refresh.
+            drain_pending_notifications(&notify_rx);
+
             let _ = async_app.update(|cx| {
                 let max_storage = Settings::read(cx, |s| s.storage.max_storage_records);
 
@@ -148,9 +181,22 @@ fn start_clipboard_monitor(
     cx: &App,
     last_copy: Arc<Mutex<LastCopyState>>,
 ) -> async_channel::Receiver<ClipboardEvent> {
-    let (clipboard_tx, clipboard_rx) = async_channel::unbounded::<ClipboardEvent>();
+    let (clipboard_tx, clipboard_rx) =
+        async_channel::bounded::<ClipboardEvent>(CLIPBOARD_EVENT_CHANNEL_CAPACITY);
     clipboard::start_clipboard_monitor(clipboard_tx, cx, last_copy);
     clipboard_rx
+}
+
+/// Drain all currently-pending `()` notifications from the channel without
+/// blocking. Used for notification coalescing: after one notification has been
+/// received, any further notifications already in the queue can be discarded
+/// because a single subsequent refresh will reflect all of them.
+fn drain_pending_notifications(notify_rx: &async_channel::Receiver<()>) -> usize {
+    let mut drained = 0usize;
+    while notify_rx.try_recv().is_ok() {
+        drained += 1;
+    }
+    drained
 }
 
 fn setup_hotkey_listener(
@@ -359,5 +405,62 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].content, "third");
         assert_eq!(records[1].content, "second");
+    }
+
+    #[test]
+    fn test_drain_pending_notifications_when_channel_has_queued_items_drains_all() {
+        let (tx, rx) = async_channel::bounded::<()>(UI_NOTIFY_CHANNEL_CAPACITY);
+
+        for _ in 0..5 {
+            tx.try_send(()).expect("Failed to enqueue notification");
+        }
+
+        let drained = drain_pending_notifications(&rx);
+
+        assert_eq!(drained, 5);
+        assert!(rx.is_empty());
+    }
+
+    #[test]
+    fn test_drain_pending_notifications_when_channel_is_empty_returns_zero() {
+        let (_tx, rx) = async_channel::bounded::<()>(UI_NOTIFY_CHANNEL_CAPACITY);
+
+        let drained = drain_pending_notifications(&rx);
+
+        assert_eq!(drained, 0);
+    }
+
+    #[test]
+    fn test_notify_channel_when_full_try_send_returns_full_error() {
+        // Simulates the producer path: when the foreground refresh task is
+        // briefly stalled, notifications coalesce by being dropped after the
+        // bounded channel saturates.
+        let (tx, rx) = async_channel::bounded::<()>(UI_NOTIFY_CHANNEL_CAPACITY);
+
+        for _ in 0..UI_NOTIFY_CHANNEL_CAPACITY {
+            tx.try_send(()).expect("Failed to enqueue notification");
+        }
+
+        let result = tx.try_send(());
+
+        assert!(matches!(result, Err(async_channel::TrySendError::Full(()))));
+        assert_eq!(rx.len(), UI_NOTIFY_CHANNEL_CAPACITY);
+    }
+
+    #[test]
+    fn test_clipboard_event_channel_has_bounded_capacity() {
+        let (tx, _rx) = async_channel::bounded::<ClipboardEvent>(CLIPBOARD_EVENT_CHANNEL_CAPACITY);
+
+        for index in 0..CLIPBOARD_EVENT_CHANNEL_CAPACITY {
+            tx.try_send(ClipboardEvent::Text(format!("event-{index}")))
+                .expect("Failed to enqueue clipboard event");
+        }
+
+        let overflow_result = tx.try_send(ClipboardEvent::Text("overflow".to_string()));
+
+        assert!(matches!(
+            overflow_result,
+            Err(async_channel::TrySendError::Full(_))
+        ));
     }
 }

--- a/src/clipboard/listener.rs
+++ b/src/clipboard/listener.rs
@@ -2,7 +2,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use async_channel::Sender;
+use async_channel::{Receiver, Sender};
 use clipboard_rs::{
     Clipboard, ClipboardContext, ClipboardHandler, ClipboardWatcher, ClipboardWatcherContext,
     ContentFormat, common::RustImage,
@@ -13,10 +13,47 @@ use image::DynamicImage;
 use super::{ClipboardEvent, LastCopyState};
 use crate::utils::{hash_file_paths, lock_or_recover, normalize_file_paths};
 
+/// Capacity for the image processing channel between the OS clipboard
+/// callback and the image-encoding background task. Images are large
+/// (`DynamicImage`), so the channel uses a single-slot, newest-wins overwrite
+/// policy: when full, the producer drops the oldest queued image and inserts
+/// the new one. This keeps memory bounded under bursty image copies while
+/// preserving the most recent (and only meaningful) payload.
+const IMAGE_PROCESSING_CHANNEL_CAPACITY: usize = 1;
+
+/// Try to enqueue an image payload with newest-wins overwrite semantics for
+/// the single-slot image processing channel.
+///
+/// On a full channel, the oldest queued image is drained via `image_drain` and
+/// the new payload is then enqueued. Returns `Ok(())` if the new payload is
+/// eventually enqueued, `Err(_)` only if the channel is closed.
+fn try_send_image_overwrite(
+    image_tx: &Sender<(DynamicImage, u64)>,
+    image_drain: &Receiver<(DynamicImage, u64)>,
+    payload: (DynamicImage, u64),
+) -> Result<(), async_channel::TrySendError<(DynamicImage, u64)>> {
+    match image_tx.try_send(payload) {
+        Ok(()) => Ok(()),
+        Err(async_channel::TrySendError::Full(payload)) => {
+            // Discard the oldest queued image; a concurrent consumer may have
+            // just drained it, in which case the slot is already free.
+            let _ = image_drain.try_recv();
+            image_tx.try_send(payload)
+        }
+        Err(closed) => Err(closed),
+    }
+}
+
 /// Clipboard monitor that sends clipboard text changes through a channel.
 struct ClipboardMonitor {
     tx: Sender<ClipboardEvent>,
     image_tx: Sender<(DynamicImage, u64)>,
+    /// Producer-side handle on the image channel used solely to drop the
+    /// oldest queued image when the single-slot channel is full
+    /// (newest-wins overwrite policy). Cloned from the same channel as
+    /// `image_tx`, so this neither prevents the consumer task from receiving
+    /// nor counts as an additional consumer of meaningful events.
+    image_drain: Receiver<(DynamicImage, u64)>,
     ctx: ClipboardContext,
     last_copy: Arc<Mutex<LastCopyState>>,
 }
@@ -25,6 +62,7 @@ impl ClipboardMonitor {
     fn new(
         tx: Sender<ClipboardEvent>,
         image_tx: Sender<(DynamicImage, u64)>,
+        image_drain: Receiver<(DynamicImage, u64)>,
         last_copy: Arc<Mutex<LastCopyState>>,
     ) -> Option<Self> {
         let ctx = match ClipboardContext::new() {
@@ -37,6 +75,7 @@ impl ClipboardMonitor {
         Some(Self {
             tx,
             image_tx,
+            image_drain,
             ctx,
             last_copy,
         })
@@ -123,55 +162,98 @@ fn detect_clipboard_payload(ctx: &ClipboardContext) -> Option<ClipboardPayload> 
 }
 
 impl ClipboardHandler for ClipboardMonitor {
-    // Don't send duplicate clipboard contents
+    // Don't send duplicate clipboard contents.
+    //
+    // Important: `LastCopyState` is advanced only after a successful enqueue.
+    // Updating it after a dropped/Full event would let the dedup gate filter
+    // out the next legitimate retry of the same content once the channel
+    // drains, turning "drop one event" into "permanently miss this content".
     fn on_clipboard_change(&mut self) {
+        // Hold the mutex only across the dedup-check + dispatch + state
+        // advance, then release it. Keeping the guard in a tight scope
+        // satisfies clippy's `significant_drop_tightening` and avoids
+        // serializing unrelated readers on heavy clipboard activity.
         let mut last_copy_guard = lock_or_recover(&self.last_copy);
+        if let Some(new_state) = self.dispatch_payload(&last_copy_guard) {
+            *last_copy_guard = new_state;
+        }
+    }
+}
 
-        match detect_clipboard_payload(&self.ctx) {
-            Some(ClipboardPayload::Files(files)) => {
+impl ClipboardMonitor {
+    /// Detect the current clipboard payload and forward it through the
+    /// appropriate channel.
+    ///
+    /// Returns `Some(new_state)` only when the event was successfully enqueued,
+    /// so the caller advances `LastCopyState` in lockstep with the channel —
+    /// dropped/Full events never poison the dedup gate.
+    fn dispatch_payload(&self, last_copy: &LastCopyState) -> Option<LastCopyState> {
+        match detect_clipboard_payload(&self.ctx)? {
+            ClipboardPayload::Files(files) => {
                 let hash = hash_file_paths(&files);
-                if should_forward_files(&last_copy_guard, hash) {
-                    // try_send: never block the OS clipboard callback thread.
-                    // If the channel is full, drop the event and warn — losing
-                    // a single event is preferable to stalling clipboard
-                    // notifications system-wide.
-                    if let Err(e) = self.tx.try_send(ClipboardEvent::Files(files)) {
+                if !should_forward_files(last_copy, hash) {
+                    return None;
+                }
+                // try_send: never block the OS clipboard callback thread.
+                // If the channel is full, drop the event and warn — losing
+                // a single event is preferable to stalling clipboard
+                // notifications system-wide. Dedup state is left untouched
+                // so the next copy of the same files can still get through.
+                match self.tx.try_send(ClipboardEvent::Files(files)) {
+                    Ok(()) => Some(LastCopyState::Files(hash)),
+                    Err(e) => {
                         tracing::warn!(error = %e, "dropping files clipboard event (channel full or closed)");
+                        None
                     }
-                    *last_copy_guard = LastCopyState::Files(hash);
                 }
             }
-            Some(ClipboardPayload::Image(dyn_img)) => {
+            ClipboardPayload::Image(dyn_img) => {
                 let hash: u64 = seahash::hash(dyn_img.as_bytes());
-
-                if should_forward_image(&last_copy_guard, hash) {
-                    if let Err(e) = self.image_tx.try_send((dyn_img, hash)) {
-                        tracing::warn!(error = %e, "dropping image clipboard event (processing channel full or closed)");
+                if !should_forward_image(last_copy, hash) {
+                    return None;
+                }
+                // Newest-wins overwrite: on a full single-slot channel,
+                // drop the oldest queued image to make room for this one.
+                match try_send_image_overwrite(&self.image_tx, &self.image_drain, (dyn_img, hash)) {
+                    Ok(()) => Some(LastCopyState::Image(hash)),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "dropping image clipboard event (processing channel closed)");
+                        None
                     }
-                    *last_copy_guard = LastCopyState::Image(hash);
                 }
             }
-            Some(ClipboardPayload::RichText {
+            ClipboardPayload::RichText {
                 plain_text,
                 html,
                 rtf,
-            }) if should_forward_text(&last_copy_guard, &plain_text) => {
-                if let Err(e) = self.tx.try_send(ClipboardEvent::RichText {
+            } => {
+                if !should_forward_text(last_copy, &plain_text) {
+                    return None;
+                }
+                match self.tx.try_send(ClipboardEvent::RichText {
                     plain_text: plain_text.clone(),
                     html,
                     rtf,
                 }) {
-                    tracing::warn!(error = %e, "dropping rich text clipboard event (channel full or closed)");
+                    Ok(()) => Some(LastCopyState::Text(plain_text)),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "dropping rich text clipboard event (channel full or closed)");
+                        None
+                    }
                 }
-                *last_copy_guard = LastCopyState::Text(plain_text);
             }
-            Some(ClipboardPayload::Text(text)) if should_forward_text(&last_copy_guard, &text) => {
-                if let Err(e) = self.tx.try_send(ClipboardEvent::Text(text.clone())) {
-                    tracing::warn!(error = %e, "dropping text clipboard event (channel full or closed)");
+            ClipboardPayload::Text(text) => {
+                if !should_forward_text(last_copy, &text) {
+                    return None;
                 }
-                *last_copy_guard = LastCopyState::Text(text);
+                match self.tx.try_send(ClipboardEvent::Text(text.clone())) {
+                    Ok(()) => Some(LastCopyState::Text(text)),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "dropping text clipboard event (channel full or closed)");
+                        None
+                    }
+                }
             }
-            _ => {}
         }
     }
 }
@@ -182,8 +264,14 @@ pub fn start_clipboard_monitor(
     cx: &App,
     last_copy: Arc<Mutex<LastCopyState>>,
 ) {
-    let (image_tx, image_rx) = async_channel::unbounded::<(DynamicImage, u64)>();
-    let Some(monitor) = ClipboardMonitor::new(tx.clone(), image_tx, last_copy) else {
+    let (image_tx, image_rx) =
+        async_channel::bounded::<(DynamicImage, u64)>(IMAGE_PROCESSING_CHANNEL_CAPACITY);
+    // Producer keeps a clone of the receiver as a drain handle so the OS
+    // callback thread can evict the oldest queued image when the single-slot
+    // channel is full. The encoder task also holds `image_rx` and is the
+    // primary consumer of meaningful events.
+    let image_drain = image_rx.clone();
+    let Some(monitor) = ClipboardMonitor::new(tx.clone(), image_tx, image_drain, last_copy) else {
         return;
     };
 
@@ -216,6 +304,7 @@ pub fn start_clipboard_monitor(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use rstest::rstest;
 
@@ -308,5 +397,119 @@ mod tests {
         let last_copy = LastCopyState::Text("hello".to_string());
 
         assert!(should_forward_files(&last_copy, 42));
+    }
+
+    /// Build a tiny `DynamicImage` for tests. Avoids decoding real image data.
+    fn make_test_image(seed: u8) -> DynamicImage {
+        let buf = image::ImageBuffer::from_pixel(1, 1, image::Rgba([seed, seed, seed, 255]));
+        DynamicImage::ImageRgba8(buf)
+    }
+
+    #[test]
+    fn test_try_send_image_overwrite_when_slot_empty_enqueues_payload() {
+        let (tx, rx) = async_channel::bounded::<(DynamicImage, u64)>(1);
+
+        let result = try_send_image_overwrite(&tx, &rx, (make_test_image(1), 100));
+
+        assert!(result.is_ok());
+        assert_eq!(rx.len(), 1);
+        let (_img, hash) = rx.try_recv().expect("payload should be enqueued");
+        assert_eq!(hash, 100);
+    }
+
+    #[test]
+    fn test_try_send_image_overwrite_when_slot_full_drops_oldest_keeps_newest() {
+        let (tx, rx) = async_channel::bounded::<(DynamicImage, u64)>(1);
+
+        // Fill the slot with an "old" image.
+        try_send_image_overwrite(&tx, &rx, (make_test_image(1), 1))
+            .expect("Failed to enqueue first image");
+
+        // Second push must succeed by overwriting (newest-wins).
+        let result = try_send_image_overwrite(&tx, &rx, (make_test_image(2), 2));
+
+        assert!(result.is_ok());
+        assert_eq!(rx.len(), 1);
+        let (_img, hash) = rx.try_recv().expect("newest payload should be enqueued");
+        assert_eq!(hash, 2, "channel should retain the newest image");
+    }
+
+    #[test]
+    fn test_try_send_image_overwrite_when_channel_closed_returns_error() {
+        let (tx, rx) = async_channel::bounded::<(DynamicImage, u64)>(1);
+        tx.close();
+
+        let result = try_send_image_overwrite(&tx, &rx, (make_test_image(1), 1));
+
+        assert!(matches!(
+            result,
+            Err(async_channel::TrySendError::Closed(_))
+        ));
+    }
+
+    /// Mirrors the `Text` branch of `on_clipboard_change`: when `try_send`
+    /// fails, `LastCopyState` must NOT advance, so a subsequent identical
+    /// copy can still be forwarded once the channel drains.
+    #[test]
+    fn test_text_branch_when_send_fails_does_not_advance_last_copy_state() {
+        let (tx, rx) = async_channel::bounded::<ClipboardEvent>(1);
+        // Saturate the channel so the next try_send returns Full.
+        tx.try_send(ClipboardEvent::Text("filler".to_string()))
+            .expect("Failed to fill channel");
+
+        let mut last_copy = LastCopyState::Text(String::new());
+        let new_text = "hello".to_string();
+
+        // Replicate the production logic: only advance state on Ok.
+        if should_forward_text(&last_copy, &new_text)
+            && tx.try_send(ClipboardEvent::Text(new_text.clone())).is_ok()
+        {
+            last_copy = LastCopyState::Text(new_text);
+        }
+
+        assert!(matches!(last_copy, LastCopyState::Text(ref t) if t.is_empty()));
+        // After draining, the same content must still be forwardable.
+        let _ = rx.try_recv();
+        assert!(should_forward_text(&last_copy, "hello"));
+    }
+
+    /// Mirrors the `Files` branch: dropped event must not poison the dedup
+    /// gate against the same files arriving again.
+    #[test]
+    fn test_files_branch_when_send_fails_does_not_advance_last_copy_state() {
+        let (tx, _rx) = async_channel::bounded::<ClipboardEvent>(1);
+        tx.try_send(ClipboardEvent::Text("filler".to_string()))
+            .expect("Failed to fill channel");
+
+        let mut last_copy = LastCopyState::Files(0);
+        let files = vec!["/tmp/a".to_string()];
+        let hash = hash_file_paths(&files);
+
+        if should_forward_files(&last_copy, hash)
+            && tx.try_send(ClipboardEvent::Files(files)).is_ok()
+        {
+            last_copy = LastCopyState::Files(hash);
+        }
+
+        // State stayed at the original hash (0), so the next retry of the
+        // same files (hash) still passes the dedup gate.
+        assert!(matches!(last_copy, LastCopyState::Files(0)));
+        assert!(should_forward_files(&last_copy, hash));
+    }
+
+    #[test]
+    fn test_text_branch_when_send_succeeds_advances_last_copy_state() {
+        let (tx, _rx) = async_channel::bounded::<ClipboardEvent>(8);
+
+        let mut last_copy = LastCopyState::Text(String::new());
+        let new_text = "hello".to_string();
+
+        if should_forward_text(&last_copy, &new_text)
+            && tx.try_send(ClipboardEvent::Text(new_text.clone())).is_ok()
+        {
+            last_copy = LastCopyState::Text(new_text);
+        }
+
+        assert!(matches!(last_copy, LastCopyState::Text(ref t) if t == "hello"));
     }
 }

--- a/src/clipboard/listener.rs
+++ b/src/clipboard/listener.rs
@@ -131,8 +131,12 @@ impl ClipboardHandler for ClipboardMonitor {
             Some(ClipboardPayload::Files(files)) => {
                 let hash = hash_file_paths(&files);
                 if should_forward_files(&last_copy_guard, hash) {
-                    if let Err(e) = self.tx.send_blocking(ClipboardEvent::Files(files)) {
-                        tracing::warn!(error = %e, "failed to send files to clipboard event channel");
+                    // try_send: never block the OS clipboard callback thread.
+                    // If the channel is full, drop the event and warn — losing
+                    // a single event is preferable to stalling clipboard
+                    // notifications system-wide.
+                    if let Err(e) = self.tx.try_send(ClipboardEvent::Files(files)) {
+                        tracing::warn!(error = %e, "dropping files clipboard event (channel full or closed)");
                     }
                     *last_copy_guard = LastCopyState::Files(hash);
                 }
@@ -141,8 +145,8 @@ impl ClipboardHandler for ClipboardMonitor {
                 let hash: u64 = seahash::hash(dyn_img.as_bytes());
 
                 if should_forward_image(&last_copy_guard, hash) {
-                    if let Err(e) = self.image_tx.send_blocking((dyn_img, hash)) {
-                        tracing::warn!(error = %e, "failed to send image to processing channel");
+                    if let Err(e) = self.image_tx.try_send((dyn_img, hash)) {
+                        tracing::warn!(error = %e, "dropping image clipboard event (processing channel full or closed)");
                     }
                     *last_copy_guard = LastCopyState::Image(hash);
                 }
@@ -152,18 +156,18 @@ impl ClipboardHandler for ClipboardMonitor {
                 html,
                 rtf,
             }) if should_forward_text(&last_copy_guard, &plain_text) => {
-                if let Err(e) = self.tx.send_blocking(ClipboardEvent::RichText {
+                if let Err(e) = self.tx.try_send(ClipboardEvent::RichText {
                     plain_text: plain_text.clone(),
                     html,
                     rtf,
                 }) {
-                    tracing::warn!(error = %e, "failed to send rich text to clipboard event channel");
+                    tracing::warn!(error = %e, "dropping rich text clipboard event (channel full or closed)");
                 }
                 *last_copy_guard = LastCopyState::Text(plain_text);
             }
             Some(ClipboardPayload::Text(text)) if should_forward_text(&last_copy_guard, &text) => {
-                if let Err(e) = self.tx.send_blocking(ClipboardEvent::Text(text.clone())) {
-                    tracing::warn!(error = %e, "failed to send text to clipboard event channel");
+                if let Err(e) = self.tx.try_send(ClipboardEvent::Text(text.clone())) {
+                    tracing::warn!(error = %e, "dropping text clipboard event (channel full or closed)");
                 }
                 *last_copy_guard = LastCopyState::Text(text);
             }
@@ -185,10 +189,13 @@ pub fn start_clipboard_monitor(
 
     cx.background_spawn(async move {
         while let Ok((image, hash)) = image_rx.recv().await {
-            if let Some(path) = super::save_image(&image, hash)
-                && let Err(e) = tx.send_blocking(ClipboardEvent::Image(path, hash))
-            {
-                tracing::warn!(error = %e, "failed to send image event to clipboard channel");
+            if let Some(path) = super::save_image(&image, hash) {
+                // This task is async, so awaiting send() here is safe and
+                // applies natural backpressure to image processing without
+                // blocking the OS clipboard callback thread.
+                if let Err(e) = tx.send(ClipboardEvent::Image(path, hash)).await {
+                    tracing::warn!(error = %e, "failed to send image event to clipboard channel");
+                }
             }
         }
     })


### PR DESCRIPTION
## Summary
Replace `async_channel::unbounded` with `bounded(256)` for the clipboard event and UI notification channels in `src/app.rs`, and coalesce UI refresh notifications so a burst of clipboard saves results in a single repository read + GPUI refresh. Also switch the OS clipboard callback path from `send_blocking` to `try_send` so a saturated channel can never stall system clipboard notifications.

## Linked Issue
Closes #72

## Changes
- **`src/app.rs`**:
  - Add `CLIPBOARD_EVENT_CHANNEL_CAPACITY` and `UI_NOTIFY_CHANNEL_CAPACITY` (both `256`).
  - Switch both channels to `async_channel::bounded`.
  - Producer side uses `try_send`; a `Full` result is debug-logged as a coalesced refresh, `Closed` is warned.
  - Consumer side calls `drain_pending_notifications` after each `recv().await` to coalesce all pending `()` into a single repository read + UI refresh.
- **`src/clipboard/listener.rs`**:
  - Switch `send_blocking` → `try_send` in `ClipboardHandler::on_clipboard_change` so the OS clipboard callback thread never blocks on a full channel; dropped events are warn-logged.
  - Image processing background task now uses async `send().await` for natural backpressure (still off the OS callback thread).
- New unit tests cover `drain_pending_notifications` (drain + empty cases) and the bounded capacity of both channels.

## Testing
- [x] `scripts/precheck.sh` passes locally (415 tests pass, clippy clean, i18n/icons/themes OK)
- [x] New unit tests cover the coalescing drain helper and bounded-channel saturation behavior
