### PR TITLE
docs: audit and prune low-value comments across src/

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -267,30 +267,21 @@ pub fn launch() {
             #[cfg(target_os = "macos")]
             crate::gui::set_activation_policy_accessory();
 
-            // Initialize gpui-component
             gpui_component::init(cx);
-
-            // Bind global application keys
             bind_application_keys(cx);
 
-            // Register settings as GPUI Global for app-wide access
+            // Settings must be installed before the I18n / repository
+            // globals because both read from it during their own init.
             let settings = load_settings();
             cx.set_global(settings.clone());
-
-            // Register I18n as GPUI Global for app-wide access
             cx.set_global(I18n::load_i18n(settings.language.clone()));
-
-            // Register tray state as GPUI Global for app-wide access
             crate::gui::tray::TrayState::register(cx);
 
-            // Sync auto-start state on application launch
             sync_autostart_on_launch(settings.autostart.enabled);
 
             let repository = initialize_repository();
             let initial_records =
                 load_initial_records(repository.as_ref(), settings.storage.max_history_records);
-
-            // Register repository as GPUI Global for app-wide access
             cx.set_global(GlobalRepository::new(repository));
 
             let shared_records = Arc::new(std::sync::RwLock::new(initial_records));
@@ -303,7 +294,9 @@ pub fn launch() {
             start_clipboard_event_handler(clipboard_rx, window_handle, cx);
             let hotkey_tx =
                 setup_hotkey_listener(window_handle, settings.hotkey.activation_key.clone(), cx);
-            // Initialize tray from the global I18n, then store the handle in global tray state.
+            // Tray initialization needs the loaded I18n; the resulting
+            // handle is stashed in the global so menu refreshes after a
+            // language change can reach it.
             let tray = crate::gui::start_tray_handler(I18n::global(cx), cx, window_handle);
             crate::gui::tray::TrayState::install(cx, tray);
 
@@ -328,7 +321,6 @@ pub fn launch() {
                 tracing::error!("failed to downcast root view to RopyBoard");
             }
 
-            // Initialize X11 control
             #[cfg(target_os = "linux")]
             if env::var("DISPLAY").is_ok() {
                 match X11::new() {

--- a/src/clipboard/writer.rs
+++ b/src/clipboard/writer.rs
@@ -4,8 +4,10 @@ use image::ImageReader;
 
 use super::CopyRequest;
 
-/// Start a background task to handle clipboard write requests.
-/// This avoids creating a new `ClipboardContext` and spawning a new task for each write.
+/// Spawn the single long-lived task that owns the OS [`ClipboardContext`].
+/// All copy operations funnel through the returned channel so we don't pay
+/// the cost of recreating the context (and re-acquiring platform handles)
+/// on every write.
 pub fn start_clipboard_writer(cx: &App) -> async_channel::Sender<CopyRequest> {
     let (tx, rx) = async_channel::unbounded();
 
@@ -53,28 +55,21 @@ fn load_image_from_path(path: &str) -> image::ImageResult<image::DynamicImage> {
         .and_then(image::ImageReader::decode)
 }
 
-/// Set text to clipboard
 fn set_text(ctx: &ClipboardContext, text: String) {
     if let Err(e) = ctx.set_text(text) {
         tracing::warn!(error = %e, "failed to set text to clipboard");
     }
 }
 
-/// Set image to clipboard. The image is read from the given file path.
-/// After setting the image, the original file and its thumbnail are deleted.
 fn set_image(ctx: &ClipboardContext, path: &str) {
     let img_res = load_image_from_path(path);
     if let Ok(img) = img_res {
         #[cfg(target_os = "macos")]
         {
-            // On macOS, `clipboard-rs`'s default `set_image` implementation clears the clipboard,
-            // then encodes the image to PNG, and finally writes it.
-            // For large images, the encoding step takes time, creating a race condition where
-            // the listener detects the "clear" event but fails to read the data because it's not written yet.
-            //
-            // To fix this, we pre-encode the image to PNG in memory and use `set_buffer` to write it.
-            // This minimizes the time window between clearing and writing, ensuring the listener
-            // finds the data when it reacts to the change event.
+            // `clipboard-rs::set_image` on macOS clears the pasteboard
+            // before encoding, so for large images the listener can fire
+            // on the empty intermediate state. Pre-encode here and use
+            // `set_buffer` to keep clear→write atomic from its POV.
             let mut bytes = Vec::new();
             if img
                 .write_to(
@@ -88,7 +83,6 @@ fn set_image(ctx: &ClipboardContext, path: &str) {
             }
         }
 
-        // Platforms other than macOS can use RustImageData directly
         #[cfg(not(target_os = "macos"))]
         {
             use clipboard_rs::common::RustImage;

--- a/src/config/autostart.rs
+++ b/src/config/autostart.rs
@@ -18,19 +18,14 @@ pub enum AutoStartError {
     StatusCheck(String),
 }
 
-/// Manager for application auto-start functionality
+/// Owns the platform `AutoLaunch` handle and threads the `--silent` flag
+/// through it so a system-triggered launch boots into the tray instead of
+/// popping the main window.
 pub struct AutoStartManager {
     auto_launch: AutoLaunch,
 }
 
 impl AutoStartManager {
-    /// Create a new `AutoStartManager` instance
-    ///
-    /// # Arguments
-    /// * `app_name` - The name of the application
-    ///
-    /// # Returns
-    /// Result containing `AutoStartManager` or `AutoStartError`
     pub fn new(app_name: &str) -> Result<Self, AutoStartError> {
         let app_path = Self::get_app_path()?;
 
@@ -46,27 +41,25 @@ impl AutoStartManager {
         Ok(Self { auto_launch })
     }
 
-    /// Get the application executable path
-    ///
-    /// For development builds, returns the debug executable path
-    /// For bundled `macOS` apps, returns the `.app` bundle path
+    /// Resolve the path that `LaunchAgents` / `.desktop` entries / the
+    /// Windows registry should point at. On macOS a release build runs
+    /// inside a `.app` bundle and the auto-launch entry must reference
+    /// the bundle, not the inner Mach-O — otherwise launchd starts a
+    /// detached binary without a working environment.
     fn get_app_path() -> Result<String, AutoStartError> {
-        // Get the current executable path
         let exe_path =
             env::current_exe().map_err(|e| AutoStartError::ExecutablePath(e.to_string()))?;
 
-        // On macOS, if we're inside a .app bundle, we need to return the bundle path
         #[cfg(target_os = "macos")]
         {
             let exe_str = exe_path.to_string_lossy();
-            // Check if we're inside a .app bundle
             if let Some(app_bundle_idx) = exe_str.rfind(".app/") {
-                let bundle_path = &exe_str[..app_bundle_idx + 4]; // Include .app
+                // +4 keeps the `.app` suffix in the slice.
+                let bundle_path = &exe_str[..app_bundle_idx + 4];
                 return Ok(bundle_path.to_string());
             }
         }
 
-        // For non-bundled or Windows builds, return the executable path
         exe_path
             .to_str()
             .map(std::string::ToString::to_string)
@@ -75,31 +68,28 @@ impl AutoStartManager {
             })
     }
 
-    /// Enable auto-start at system startup
     pub fn enable(&self) -> Result<(), AutoStartError> {
         self.auto_launch
             .enable()
             .map_err(|e| AutoStartError::Enable(e.to_string()))
     }
 
-    /// Disable auto-start at system startup
     pub fn disable(&self) -> Result<(), AutoStartError> {
         self.auto_launch
             .disable()
             .map_err(|e| AutoStartError::Disable(e.to_string()))
     }
 
-    /// Check if auto-start is currently enabled
     pub fn is_enabled(&self) -> Result<bool, AutoStartError> {
         self.auto_launch
             .is_enabled()
             .map_err(|e| AutoStartError::StatusCheck(e.to_string()))
     }
 
-    /// Synchronize auto-start state with the given enabled flag
-    ///
-    /// # Arguments
-    /// * `enabled` - Whether auto-start should be enabled
+    /// Make the system state match the user's preference, but skip the
+    /// platform call when it already matches — repeatedly toggling
+    /// `LaunchAgents` / registry entries is unnecessary churn and (on
+    /// some Linux desktops) racy.
     pub fn sync_state(&self, enabled: bool) -> Result<(), AutoStartError> {
         let current_enabled = self.is_enabled().unwrap_or(false);
         if current_enabled == enabled {

--- a/src/config/settings/mod.rs
+++ b/src/config/settings/mod.rs
@@ -12,16 +12,13 @@ use crate::{
 
 mod validate;
 
-/// Default maximum number of records to display in the UI
 const DEFAULT_MAX_HISTORY_RECORDS: usize = 100;
-/// Default maximum number of records to store in the repository
 const DEFAULT_MAX_STORAGE_RECORDS: usize = 200;
-/// Minimum supported window opacity percentage.
+/// 40% is the lowest opacity that still keeps text legible during testing;
+/// going lower made the UI effectively unusable.
 const MIN_WINDOW_OPACITY_PERCENT: u8 = 40;
-/// Maximum supported window opacity percentage.
 const MAX_WINDOW_OPACITY_PERCENT: u8 = 100;
 
-/// Application settings structure
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Settings {
     pub hotkey: HotkeySettings,
@@ -37,19 +34,20 @@ pub struct Settings {
 }
 
 impl Settings {
-    /// Get the configuration directory path
     pub fn config_dir() -> Result<PathBuf, ConfigError> {
         dirs::config_dir()
             .map(|dir| dir.join("ropy"))
             .ok_or_else(|| ConfigError::NotFound("Config directory not found".to_string()))
     }
 
-    /// Get the configuration file path
     pub fn config_file() -> Result<PathBuf, ConfigError> {
         Ok(Self::config_dir()?.join("config.toml"))
     }
 
-    /// Load settings from configuration file and environment variables
+    /// Load settings, layering the on-disk `config.toml` over the
+    /// `Default` instance so partial files keep working across upgrades,
+    /// and clamping each value group via [`validate`] so out-of-range
+    /// values on disk can't propagate into the running app.
     pub fn load() -> Result<Self, ConfigError> {
         let config_dir = Self::config_dir()?;
         let config_file = config_dir.join("config");
@@ -81,7 +79,6 @@ impl Settings {
         Ok(settings)
     }
 
-    /// Save settings to configuration file
     pub fn save(&self) -> Result<(), ConfigError> {
         let config_file = Self::config_file()?;
         let toml_string =
@@ -135,13 +132,13 @@ pub struct LayoutSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ConfirmSettings {
-    /// Behavior when confirming a record from the board
     pub mode: ConfirmMode,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WindowSettings {
-    /// Window opacity percentage in the settings UI (40 - 100).
+    /// Allowed range is [`MIN_OPACITY_PERCENT`..=`MAX_OPACITY_PERCENT`];
+    /// values outside that band are clamped at load time.
     pub opacity_percent: u8,
 }
 
@@ -166,7 +163,8 @@ impl WindowSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HotkeySettings {
-    /// Global hotkey to activate clipboard manager (e.g., "`cmd+shift+v`")
+    /// `+`-separated chord parsed by `global_hotkey` (e.g. `cmd+shift+v`).
+    /// Invalid values are reset to the default by [`validate_hotkey`].
     pub activation_key: String,
 }
 
@@ -183,10 +181,13 @@ impl Default for HotkeySettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageSettings {
-    /// Maximum number of records to display in the UI (1 - 10,000)
+    /// Soft cap on records visible in the board (1 – 10,000). Records past
+    /// this point are kept on disk but hidden until older entries are
+    /// pinned / cleared.
     pub max_history_records: usize,
-    /// Maximum number of records to store in the repository (1 - 100,000)
-    /// Must be >= `max_history_records`
+    /// Hard cap before cleanup deletes records (1 – 100,000). Validation
+    /// ensures `max_storage_records >= max_history_records` so the
+    /// visible window can always be filled.
     pub max_storage_records: usize,
 }
 
@@ -201,15 +202,12 @@ impl Default for StorageSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AutoStartSettings {
-    /// Whether to enable auto-launch at system startup
     pub enabled: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateSettings {
-    /// Whether to automatically check for updates on startup
     pub auto_check: bool,
-    /// Whether to include pre-release versions
     pub include_prerelease: bool,
 }
 
@@ -224,7 +222,6 @@ impl Default for UpdateSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PreviewSettings {
-    /// Whether to enable hover preview for clipboard items
     pub hover_preview_enabled: bool,
 }
 
@@ -239,7 +236,8 @@ impl Default for PreviewSettings {
 impl Global for Settings {}
 
 impl Settings {
-    /// Read a value from the global settings via a closure.
+    /// Closure-style accessor to the global instance — keeps call sites
+    /// from holding a borrow of `cx` longer than the field they need.
     pub fn read<R>(cx: &App, reader: impl FnOnce(&Self) -> R) -> R {
         reader(Self::global(cx))
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,17 +1,12 @@
-#![allow(clippy::empty_line_after_doc_comments)]
+//! Cross-module constants whose values are not user-localizable.
 
-/// Application-wide constants used throughout the codebase.
-/// The only public constant defined today is the display name of the
-/// application.  Historically this string lived in the i18n translation
-/// files, but it never needs localisation – the name of the app is always
-/// "Ropy" regardless of UI language.  Keeping it in a central constant
-/// reduces duplication and simplifies the translation files.
-
-/// Name presented to the user in tooltips, window titles, about panel, etc.
+/// Display name shown in tray tooltips, window titles, the About panel,
+/// etc. Intentionally not in the i18n bundles — the product name stays
+/// "Ropy" in every locale.
 pub const APP_NAME: &str = "Ropy";
 
-/// CLI argument for silent/auto-start mode (no window shown on startup)
+/// Hidden CLI flag used by the auto-start launcher to suppress the
+/// initial window so the app boots silently into the tray.
 pub const SILENT_ARG: &str = "--silent";
 
-/// Arrow used for the "back" button in the about panel.
 pub const BACK_ARROW: &str = "←";

--- a/src/gui/board/clear_confirm.rs
+++ b/src/gui/board/clear_confirm.rs
@@ -12,7 +12,6 @@ use gpui_component::{
 use super::{RopyBoard, filtering::ClearConfirmAction};
 use crate::i18n::I18n;
 
-/// Render the clear-all confirmation overlay (backdrop + centered dialog card)
 pub(super) fn render_clear_confirm_overlay(
     action: ClearConfirmAction,
     cx: &Context<'_, RopyBoard>,

--- a/src/gui/board/filtering.rs
+++ b/src/gui/board/filtering.rs
@@ -51,7 +51,6 @@ pub(super) fn plan_filtered_records_sync(
     }
 }
 
-/// Sort and filter record indices by search query, content type, and display order.
 pub(super) fn filter_and_sort_record_indices(
     records: &[ClipboardRecord],
     query: &str,

--- a/src/gui/board/header.rs
+++ b/src/gui/board/header.rs
@@ -11,7 +11,6 @@ use gpui_component::{
 use super::RopyBoard;
 use crate::{constants::APP_NAME, i18n::I18n};
 
-/// Render the header section with title and window action buttons
 pub fn render_header(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl IntoElement {
     let is_pinned = board.pinned;
     let can_toggle_window_pin = board.can_toggle_window_pin();

--- a/src/gui/board/hotkey_record_handler.rs
+++ b/src/gui/board/hotkey_record_handler.rs
@@ -5,8 +5,6 @@ use gpui::{Context, Focusable, Keystroke, Modifiers, Window};
 
 use super::RopyBoard;
 
-// --- Hotkey recording utilities (merged from gui/hotkey_record.rs) ---
-
 fn keystroke_to_hotkey(keystroke: &Keystroke) -> Option<String> {
     if !has_supported_modifier(keystroke.modifiers) {
         return None;
@@ -139,8 +137,6 @@ fn is_modifier_key(key: &str) -> bool {
         "shift" | "control" | "ctrl" | "alt" | "cmd" | "command" | "super" | "fn"
     )
 }
-
-// --- RopyBoard hotkey recording methods ---
 
 impl RopyBoard {
     pub(crate) fn start_hotkey_recording(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/src/gui/board/preview.rs
+++ b/src/gui/board/preview.rs
@@ -1,6 +1,8 @@
+//! Custom tooltip views that wrap automatically and stay within the
+//! window's bounds — GPUI's built-in tooltip helpers don't expose either.
+
 use std::path::PathBuf;
 
-/// Custom tooltip preview implementation that supports automatic line wrapping
 use gpui::{
     AnyView, App, AppContext, IntoElement, ParentElement, Render, Styled, Window, div, img, px,
 };
@@ -11,17 +13,8 @@ const TOOLTIP_HORIZONTAL_MARGIN_PX: f32 = 40.0;
 const IMAGE_TOOLTIP_MAX_WIDTH_PX: f32 = 600.0;
 const IMAGE_TOOLTIP_MAX_HEIGHT_PX: f32 = 400.0;
 
-/// Create a tooltip preview that supports automatic line wrapping
-///
-/// This implementation returns a `View` that will be correctly rendered by `GPUI`'s tooltip system
-///
-/// # Usage Example
-/// ```rust
-/// div()
-///     .tooltip(|window, cx| {
-///         simple_tooltip("This is tooltip content", window, cx)
-///     })
-/// ```
+/// Build a text tooltip whose width is capped against the current window so
+/// long lines wrap instead of being clipped.
 pub fn simple_tooltip(content: impl Into<String>, window: &Window, cx: &mut App) -> AnyView {
     let content = content.into();
     let window_width = window.bounds().size.width;
@@ -62,15 +55,8 @@ impl Render for TooltipView {
     }
 }
 
-/// Create an image tooltip preview
-///
-/// # Usage Example
-/// ```rust
-/// div()
-///     .tooltip(|window, cx| {
-///         image_tooltip("/path/to/image.png", window, cx)
-///     })
-/// ```
+/// Build an image tooltip scaled to fit within the current window while
+/// respecting an absolute maximum so previews stay readable on large screens.
 pub fn image_tooltip(image_path: impl Into<String>, window: &Window, cx: &mut App) -> AnyView {
     let image_path = image_path.into();
     let window_width = window.bounds().size.width;

--- a/src/gui/board/record_ops.rs
+++ b/src/gui/board/record_ops.rs
@@ -106,7 +106,9 @@ impl RopyBoard {
         self.sync_filtered_records(cx);
     }
 
-    /// Clear clipboard history
+    /// Wipe everything — including pinned and favorited records — used by
+    /// the "clear all" path. Most callers want
+    /// [`Self::clear_ordinary_history`] instead.
     pub(crate) fn clear_history(&mut self, cx: &Context<Self>) {
         GlobalRepository::read(cx, |repo| {
             if let Some(repo) = repo {
@@ -124,7 +126,7 @@ impl RopyBoard {
         });
     }
 
-    /// Clear only ordinary clipboard history, preserving pinned and favorited records.
+    /// Default "clear history" path: pinned and favorited records survive.
     pub(crate) fn clear_ordinary_history(&mut self, cx: &Context<Self>) {
         GlobalRepository::read(cx, |repo| {
             if let Some(repo) = repo {
@@ -156,13 +158,13 @@ impl RopyBoard {
         self.clear_last_copy_state();
     }
 
-    /// Clear last copy state
+    /// Reset the dedup gate so the next copy — even if identical to the
+    /// just-cleared content — is recaptured by the listener.
     pub(crate) fn clear_last_copy_state(&self) {
         let mut guard = lock_or_recover(&self.last_copy);
         *guard = LastCopyState::Text(String::new());
     }
 
-    /// Delete a single record by ID
     pub fn delete_record(&mut self, id: u64, cx: &Context<Self>) {
         GlobalRepository::read(cx, |repo| {
             if let Some(repo) = repo {
@@ -176,7 +178,6 @@ impl RopyBoard {
         });
     }
 
-    /// Toggle favorite state of a record.
     pub fn toggle_record_favorite(&mut self, id: u64, cx: &Context<Self>) {
         GlobalRepository::read(cx, |repo| {
             let Some(repo) = repo else {
@@ -193,7 +194,6 @@ impl RopyBoard {
         });
     }
 
-    /// Toggle pin state of a record
     pub fn toggle_record_pin(&mut self, id: u64, cx: &Context<Self>) {
         GlobalRepository::read(cx, |repo| {
             let Some(repo) = repo else {
@@ -207,7 +207,8 @@ impl RopyBoard {
         });
     }
 
-    /// Toggle the content type filter. Clicking the same filter again resets to All.
+    /// Click-to-toggle behavior: re-clicking the active filter clears it
+    /// (back to `All`) so the same button serves as both apply and reset.
     pub(crate) fn toggle_content_filter(&mut self, target: ContentFilter) {
         if self.content_filter == target {
             self.content_filter = ContentFilter::All;
@@ -216,7 +217,8 @@ impl RopyBoard {
         }
     }
 
-    /// Toggle the favorites-only filter (independent of content type filter).
+    /// Favorites toggle is intentionally orthogonal to the content filter
+    /// so users can scope to e.g. "favorited images only".
     pub(crate) const fn toggle_favorites_only(&mut self) {
         self.favorites_only = !self.favorites_only;
     }
@@ -229,7 +231,6 @@ impl RopyBoard {
         self.search_options.whole_word = !self.search_options.whole_word;
     }
 
-    /// Get filtered records based on search query and content type filter
     pub(super) fn get_filtered_record_indices(&self, query: &str) -> Vec<usize> {
         let records = read_or_recover(&self.records);
         filter_and_sort_record_indices(

--- a/src/gui/board/settings_editor.rs
+++ b/src/gui/board/settings_editor.rs
@@ -93,7 +93,6 @@ impl UpdateManager {
     }
 }
 
-/// Build the window opacity slider and subscribe to its change events.
 pub(super) fn build_window_opacity_slider(
     opacity_percent: u8,
     window: &Window,
@@ -152,7 +151,6 @@ pub(super) fn sync_layout_select_items(
     });
 }
 
-/// Build the layout select dropdown and subscribe to its change events.
 pub(super) fn build_layout_select(
     selected_layout: usize,
     window: &mut Window,
@@ -187,7 +185,6 @@ pub(super) fn build_layout_select(
     layout_select
 }
 
-/// Build the theme select dropdown and subscribe to its change events.
 pub(super) fn build_theme_select(
     selected_theme: usize,
     window: &mut Window,
@@ -226,7 +223,6 @@ pub(super) fn build_theme_select(
     theme_select
 }
 
-/// Build the language select dropdown and subscribe to its change events.
 pub(super) fn build_language_select(
     selected_language: usize,
     window: &mut Window,

--- a/src/gui/board/updater_ui.rs
+++ b/src/gui/board/updater_ui.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 impl RopyBoard {
-    /// Trigger a manual update check in the background
     pub fn check_for_update_async(&mut self, cx: &mut Context<Self>) {
         self.update_manager.status = UpdateStatus::Checking;
         cx.notify();
@@ -39,7 +38,6 @@ impl RopyBoard {
         .detach();
     }
 
-    /// Trigger download and install in the background with progress updates
     pub fn download_and_install_update(&mut self, cx: &mut Context<Self>) {
         let release = match &self.update_manager.status {
             UpdateStatus::Available(info) => info.clone(),
@@ -48,8 +46,8 @@ impl RopyBoard {
         self.update_manager.status = UpdateStatus::Downloading(0.0);
         cx.notify();
 
-        // Progress channel is still needed because download_and_install reports
-        // incremental progress via an async_channel::Sender<f32>.
+        // download_and_install reports incremental progress via the
+        // sender, so we pair it with a foreground listener below.
         let (progress_tx, progress_rx) = async_channel::unbounded::<f32>();
 
         let download_task = cx.background_spawn(async move {
@@ -57,9 +55,9 @@ impl RopyBoard {
         });
 
         cx.spawn(async move |this, cx| {
-            // Listen for progress updates on the foreground thread and
-            // refresh the UI in real time. The loop exits when the sender
-            // is dropped (download finishes or fails).
+            // Loop exits naturally once the background task drops the
+            // sender (download succeeds or fails), which is what lets us
+            // collect the final result on the next line.
             while let Ok(progress) = progress_rx.recv().await {
                 let _ = this.update(cx, |board, cx| {
                     board.update_manager.status = UpdateStatus::Downloading(progress);
@@ -67,7 +65,6 @@ impl RopyBoard {
                 });
             }
 
-            // Download is done – collect the result and update final status
             let result: Result<(), UpdateError> = download_task.await;
 
             let _ = this.update(cx, |board, cx| {

--- a/src/gui/panel/about.rs
+++ b/src/gui/panel/about.rs
@@ -18,13 +18,8 @@ use crate::{
     updater::models::UpdateStatus,
 };
 
-/// GitHub repository URL for the application.
-const GITHUB_URL: &str = "https://github.com/StudentWeis/ropy";
-
-/// MIT License URL for the application.
 const LICENSE_URL: &str = "https://github.com/StudentWeis/ropy/blob/main/LICENSE";
-
-/// Xiaohongshu profile URL for the application.
+const GITHUB_URL: &str = "https://github.com/StudentWeis/ropy";
 const XIAOHONGSHU_URL: &str = "https://xhslink.com/m/Ar6O3JkYc0X";
 
 fn render_social_link_button(
@@ -44,7 +39,6 @@ fn render_social_link_button(
     )
 }
 
-/// Render the about panel content
 pub fn render_about_content(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl IntoElement {
     let version = env!("CARGO_PKG_VERSION");
 
@@ -127,7 +121,6 @@ pub fn render_about_content(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl 
     )
 }
 
-/// Render the update section with status and action button.
 fn render_update_section(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl IntoElement {
     let status_text: gpui::SharedString = match &board.update_manager.status {
         UpdateStatus::Idle => I18n::translate(cx, "update_check_now").into(),
@@ -147,7 +140,9 @@ fn render_update_section(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl Int
         .into(),
         UpdateStatus::ReadyToRestart => I18n::translate(cx, "update_restart").into(),
         UpdateStatus::Error(msg) => {
-            // Map technical error messages to user-friendly descriptions
+            // Surface a localized "network problem" hint for the most common
+            // class of update failures so users aren't shown raw curl /
+            // TLS errors.
             let friendly_msg = if msg.contains("curl")
                 || msg.contains("SSL")
                 || msg.contains("HTTP request failed")

--- a/src/gui/panel/help.rs
+++ b/src/gui/panel/help.rs
@@ -14,10 +14,11 @@ use crate::{
     i18n::I18n,
 };
 
-/// A single row in the shortcuts table
 struct ShortcutRow {
     key: &'static str,
     label_key: &'static str,
+    /// When true, this shortcut is hidden in list mode because the action
+    /// (horizontal navigation) only makes sense in the grid layout.
     grid_only: bool,
 }
 
@@ -89,7 +90,6 @@ const SHORTCUTS: &[ShortcutRow] = &[
     },
 ];
 
-/// Render the help panel (keyboard shortcuts overview)
 #[allow(clippy::too_many_lines)]
 pub fn render_help_content(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl IntoElement {
     let header = panel_header_with_back(
@@ -137,9 +137,10 @@ pub fn render_help_content(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl I
         .filter(|row| board.can_toggle_window_pin() || row.label_key != "help_pin")
         .enumerate()
         .map(|(i, row)| {
-            // Resolve label: "help_nav_up_down" needs to combine two keys
+            // The "up / down" entry has no single translation key — compose
+            // it from the per-direction strings so each language can phrase
+            // them independently.
             let label = if row.label_key == "help_nav_up_down" {
-                // Concat the two individual translated strings
                 format!(
                     "{} / {}",
                     I18n::translate(cx, "help_nav_up"),

--- a/src/gui/panel/settings.rs
+++ b/src/gui/panel/settings.rs
@@ -24,7 +24,6 @@ use crate::{
     i18n::{I18n, Language},
 };
 
-/// Render a settings row with label centered against the control.
 fn settings_row<C: IntoElement>(
     label: impl Into<gpui::SharedString>,
     control: C,
@@ -45,7 +44,6 @@ fn settings_row<C: IntoElement>(
         .child(control)
 }
 
-/// Render a section label displayed above a settings card.
 fn settings_section_label(
     label: impl Into<gpui::SharedString>,
     cx: &Context<RopyBoard>,
@@ -58,7 +56,6 @@ fn settings_section_label(
         .child(label.into())
 }
 
-/// Render a card container that groups related settings rows.
 fn settings_card(cx: &Context<RopyBoard>) -> gpui::Div {
     v_flex()
         .w_full()
@@ -67,7 +64,6 @@ fn settings_card(cx: &Context<RopyBoard>) -> gpui::Div {
         .bg(cx.theme().secondary)
 }
 
-/// Interleave settings rows with dividers inside a card.
 fn card_with_rows(rows: Vec<gpui::AnyElement>, cx: &Context<RopyBoard>) -> impl IntoElement {
     let mut card = settings_card(cx);
     let last_index = rows.len().saturating_sub(1);
@@ -80,7 +76,6 @@ fn card_with_rows(rows: Vec<gpui::AnyElement>, cx: &Context<RopyBoard>) -> impl 
     card
 }
 
-/// Render the settings panel content with grouped card sections.
 pub fn render_settings_content(board: &RopyBoard, cx: &Context<RopyBoard>) -> impl IntoElement {
     let header = render_settings_header(cx);
 

--- a/src/gui/theme.rs
+++ b/src/gui/theme.rs
@@ -4,14 +4,17 @@ use rust_embed::RustEmbed;
 use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
-/// Embedded theme TOML files from `assets/themes/`.
+/// Bundled theme TOML files. Adding a `<id>.toml` under `assets/themes/`
+/// is enough to make the theme selectable — no Rust code change required.
 #[derive(RustEmbed)]
 #[folder = "assets/themes"]
 struct ThemeAssets;
 
 static DISPLAY_NAMES: OnceLock<HashMap<String, String>> = OnceLock::new();
 
-/// A theme identified by its file name (without `.toml`).
+/// Theme identifier — the bundle file name without the `.toml` suffix.
+/// Serialized transparently as the raw string so existing `config.toml`
+/// values keep working.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct ThemeId(String);
@@ -57,7 +60,8 @@ impl<'de> Deserialize<'de> for ThemeId {
     }
 }
 
-/// Base appearance mode required by `gpui-component`.
+/// Appearance hint required by `gpui-component`'s theme runtime so it can
+/// pick the right base styles before our palette is layered on top.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ThemeMode {
@@ -65,7 +69,6 @@ pub enum ThemeMode {
     Dark,
 }
 
-/// A theme definition loaded from a bundled TOML file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ThemeDefinition {
     id: ThemeId,
@@ -194,7 +197,7 @@ impl ThemeDefinition {
     }
 }
 
-/// Palette values applied to `gpui-component::theme::Theme`.
+/// Palette values copied into `gpui-component::theme::Theme` at apply time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ThemePalette {
     pub background: u32,

--- a/src/gui/tray.rs
+++ b/src/gui/tray.rs
@@ -61,7 +61,6 @@ impl TrayState {
     }
 }
 
-/// Build a tray menu with translated labels.
 pub fn build_tray_menu(i18n: &I18n) -> Result<Menu, Box<dyn std::error::Error>> {
     let show_item = MenuItem::with_id(TRAY_SHOW_ID, i18n.t("tray_show"), true, None);
     let quit_item = MenuItem::with_id(TRAY_QUIT_ID, i18n.t("tray_quit"), true, None);
@@ -72,7 +71,6 @@ pub fn build_tray_menu(i18n: &I18n) -> Result<Menu, Box<dyn std::error::Error>> 
     Ok(tray_menu)
 }
 
-/// Initialize and return the tray icon
 pub fn init_tray(i18n: &I18n) -> Result<(TrayIcon, MenuId, MenuId), Box<dyn std::error::Error>> {
     let tray_menu = build_tray_menu(i18n)?;
     let show_id = MenuId::new(TRAY_SHOW_ID);
@@ -80,7 +78,6 @@ pub fn init_tray(i18n: &I18n) -> Result<(TrayIcon, MenuId, MenuId), Box<dyn std:
 
     let icon = create_icon()?;
 
-    // Create tray icon
     let tray = TrayIconBuilder::new()
         .with_menu(Box::new(tray_menu))
         .with_tooltip(APP_NAME)
@@ -91,7 +88,6 @@ pub fn init_tray(i18n: &I18n) -> Result<(TrayIcon, MenuId, MenuId), Box<dyn std:
     Ok((tray, show_id, quit_id))
 }
 
-/// Create a simple icon for the tray
 fn create_icon() -> Result<Icon, Box<dyn std::error::Error>> {
     let asset = super::app::Assets::get("logo.png").ok_or("Failed to find embedded logo.png")?;
     let (rgba, width, height) = load_tray_icon_rgba(&asset.data)?;
@@ -192,7 +188,6 @@ fn spawn_tray_event_loop(
     .detach();
 }
 
-/// Start the system tray handler
 pub fn start_tray_handler_inner(
     i18n: &I18n,
     tx: async_channel::Sender<TrayEvent>,
@@ -214,7 +209,6 @@ pub fn start_tray_handler_inner(
     }
 }
 
-/// Send the active action to the main window
 pub fn send_active_action(window_handle: WindowHandle<Root>, cx: &mut gpui::App) {
     window_handle
         .update(cx, |_, window: &mut gpui::Window, cx| {

--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -1,3 +1,17 @@
+//! Window / display helpers.
+//!
+//! Most `unsafe` blocks below share the same invariants:
+//!   * `hwnd` originates from a live GPUI `Window` handle and never
+//!     outlives the enclosing stack frame, so passing it to Win32 APIs
+//!     can't dangle.
+//!   * Out-pointers (`RECT`, `MONITORINFO`, …) point to locals declared
+//!     immediately above, owned for the duration of the call.
+//!   * No call transfers ownership of `hwnd` or otherwise mutates global
+//!     state that we don't already drive.
+//!
+//! Per-block `// SAFETY:` notes only call out additional, block-specific
+//! invariants on top of the above.
+
 use std::cfg_select;
 
 use gpui::{Context, Hsla, Pixels, Size, Window, hsla};
@@ -11,26 +25,11 @@ pub fn surface_with_opacity(color: Hsla, opacity_percent: u8) -> Hsla {
     )
 }
 
-/// Spawn a named thread that runs a blocking receive loop and forwards mapped
-/// events to an `async_channel::Sender`.
-///
-/// `receive_loop` is called with a closure that the caller invokes for each
-/// received event. The closure accepts `Option<T>`: `None` values are skipped
-/// (filtered), and `Some(value)` values are forwarded. It returns `true` while
-/// the sender is still connected; the caller should stop when it returns `false`.
-///
-/// # Example
-///
-/// ```ignore
-/// let receiver = GlobalHotKeyEvent::receiver().clone();
-/// spawn_event_forwarder("hotkey-forwarder", sender, move |forward| {
-///     while let Ok(event) = receiver.recv() {
-///         if !forward(Some(ListenerMessage::HotkeyEvent(event))) {
-///             break;
-///         }
-///     }
-/// });
-/// ```
+/// Bridge a blocking OS receiver onto an `async_channel::Sender` from a
+/// dedicated thread. The forwarding closure returns `false` once the
+/// async receiver is gone, signalling the loop to break — without that
+/// signal the OS callback would keep buffering events for a consumer
+/// that no longer exists.
 pub fn spawn_event_forwarder<T, F>(
     thread_name: &str,
     sender: async_channel::Sender<T>,
@@ -147,7 +146,7 @@ fn calculate_activation_window_geometry(
 
 #[cfg(target_os = "windows")]
 fn window_frame_extents(hwnd: *mut std::ffi::c_void) -> WindowFrameExtents {
-    // SAFETY: `hwnd` comes from GPUI's live window handle; querying geometry APIs is read-only.
+    // SAFETY: see module-level note. Read-only geometry queries.
     unsafe {
         if IsIconic(hwnd) != 0 {
             return WindowFrameExtents::default();
@@ -188,8 +187,7 @@ fn window_frame_extents(hwnd: *mut std::ffi::c_void) -> WindowFrameExtents {
 
 #[cfg(target_os = "windows")]
 fn current_monitor_scale_factor(hwnd: *mut std::ffi::c_void) -> Option<f32> {
-    // SAFETY: `hwnd` is a valid live window handle; `MonitorFromWindow` returns the nearest
-    // monitor handle when one is available.
+    // SAFETY: see module-level note.
     let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
     if monitor.is_null() {
         return None;
@@ -197,13 +195,14 @@ fn current_monitor_scale_factor(hwnd: *mut std::ffi::c_void) -> Option<f32> {
 
     let mut dpi_x = 0;
     let mut dpi_y = 0;
-    // SAFETY: `monitor` was returned by `MonitorFromWindow`; the out-pointers are valid.
+    // SAFETY: `monitor` came from `MonitorFromWindow` above and out-pointers
+    // address the locals just declared.
     let status = unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) };
     if status == 0 && dpi_x > 0 && dpi_x == dpi_y {
         return Some(dpi_x as f32 / USER_DEFAULT_SCREEN_DPI as f32);
     }
 
-    // SAFETY: `hwnd` is valid; this is a read-only fallback if the monitor DPI query fails.
+    // SAFETY: per-monitor DPI failed, fall back to the window-scoped query.
     let dpi = unsafe { GetDpiForWindow(hwnd) };
     let effective_dpi = if dpi > 0 {
         dpi
@@ -218,7 +217,7 @@ fn reset_window_geometry_with_current_monitor_dpi(
     hwnd: *mut std::ffi::c_void,
     logical_size: Size<Pixels>,
 ) -> bool {
-    // SAFETY: `hwnd` is a valid window handle; `MonitorFromWindow` returns the nearest monitor.
+    // SAFETY: see module-level note.
     let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
     if monitor.is_null() {
         return false;
@@ -228,7 +227,7 @@ fn reset_window_geometry_with_current_monitor_dpi(
         cbSize: std::mem::size_of::<MONITORINFO>() as u32,
         ..unsafe { std::mem::zeroed() }
     };
-    // SAFETY: `monitor` is valid and `monitor_info` points to writable storage.
+    // SAFETY: `monitor` is the handle just returned by `MonitorFromWindow`.
     if unsafe { GetMonitorInfoW(monitor, &mut monitor_info) } == 0 {
         return false;
     }
@@ -248,7 +247,9 @@ fn reset_window_geometry_with_current_monitor_dpi(
         window_frame_extents(hwnd),
     );
 
-    // SAFETY: `hwnd` is valid; we only adjust size and position before the later restore/activate.
+    // SAFETY: pure size + position update, no Z-order or focus change
+    // (`SWP_NOACTIVATE | SWP_NOZORDER`) so it can't race with the later
+    // restore / activate path.
     unsafe {
         SetWindowPos(
             hwnd,
@@ -278,7 +279,8 @@ pub fn reset_window_geometry_for_activation(window: &mut Window, logical_size: S
     window.resize(logical_size);
 }
 
-/// Hide the window based on the platform
+/// Hide (without destroying) the active window using the platform-native
+/// path so subsequent `active_window` calls can restore it.
 #[allow(unused_variables, clippy::needless_pass_by_ref_mut)]
 pub fn hide_window<T>(window: &mut Window, cx: &Context<T>, pinned: bool) {
     if pinned {
@@ -289,9 +291,7 @@ pub fn hide_window<T>(window: &mut Window, cx: &Context<T>, pinned: bool) {
         && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
     {
         let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
-        // SAFETY: The hwnd is obtained from the valid window handle via HasWindowHandle trait.
-        // ShowWindow is safe to call with any valid window handle. SW_HIDE simply hides the
-        // window without destroying it, which is the intended behavior for hiding the window.
+        // SAFETY: see module-level note. `SW_HIDE` only toggles visibility.
         unsafe {
             ShowWindow(hwnd, SW_HIDE);
         }
@@ -312,7 +312,8 @@ pub fn hide_window<T>(window: &mut Window, cx: &Context<T>, pinned: bool) {
     }
 }
 
-/// Activate the window based on the platform
+/// Restore the window and pull it to the foreground, mirroring the user's
+/// expectation that activating from the tray / hotkey gives focus.
 #[allow(unused_variables, clippy::needless_pass_by_ref_mut)]
 pub fn active_window<T>(window: &mut Window, cx: &Context<T>) {
     #[cfg(target_os = "windows")]
@@ -320,9 +321,8 @@ pub fn active_window<T>(window: &mut Window, cx: &Context<T>) {
         && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
     {
         let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
-        // SAFETY: The hwnd comes from gpui's live window handle. Calling ShowWindow and
-        // SetForegroundWindow with this handle only changes visibility/focus state and does
-        // not transfer ownership or outlive the window's lifetime in this scope.
+        // SAFETY: see module-level note. Both calls only affect
+        // visibility / focus.
         unsafe {
             ShowWindow(hwnd, SW_RESTORE);
             SetForegroundWindow(hwnd);
@@ -344,7 +344,8 @@ pub fn active_window<T>(window: &mut Window, cx: &Context<T>) {
     }
 }
 
-/// Set the window to be always on top
+/// Toggle the always-on-top Z-order on platforms that expose it
+/// (macOS uses the `AppKit` equivalent at the GPUI level instead).
 #[allow(unused_variables)]
 #[cfg(not(target_os = "macos"))]
 pub fn set_always_on_top(window: &Window, pinned: bool) {
@@ -353,10 +354,8 @@ pub fn set_always_on_top(window: &Window, pinned: bool) {
         && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
     {
         let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
-        // SAFETY: The hwnd is obtained from the valid window handle via HasWindowHandle trait.
-        // SetWindowPos is called with SWP_NOMOVE | SWP_NOSIZE to only change the Z-order
-        // (topmost state) without affecting position or size. The hwnd_insert_after value
-        // is either HWND_TOPMOST or HWND_NOTOPMOST, both of which are valid system constants.
+        // SAFETY: see module-level note. `SWP_NOMOVE | SWP_NOSIZE` keeps
+        // geometry untouched, so this only flips Z-order.
         unsafe {
             use windows_sys::Win32::UI::WindowsAndMessaging::{
                 HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos,
@@ -375,7 +374,8 @@ pub fn set_always_on_top(window: &Window, pinned: bool) {
     }
 }
 
-/// Start dragging the window
+/// Start an OS-managed drag — the only way to move borderless windows on
+/// Windows without re-implementing the entire DWM hit-test loop.
 #[cfg(target_os = "windows")]
 pub fn start_window_drag(window: &Window) {
     use windows_sys::Win32::UI::{
@@ -386,11 +386,8 @@ pub fn start_window_drag(window: &Window) {
         && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
     {
         let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
-        // SAFETY: The hwnd is obtained from the valid window handle via HasWindowHandle trait.
-        // ReleaseCapture releases any mouse capture and is safe to call even if no capture exists.
-        // PostMessageA posts a WM_NCLBUTTONDOWN message with HTCAPTION to simulate dragging the
-        // window's title bar. This is a standard technique for implementing custom window drag
-        // and is safe as the message is handled by the window manager.
+        // SAFETY: see module-level note. `WM_NCLBUTTONDOWN` + `HTCAPTION`
+        // is the documented "synthesize a title-bar drag" pattern.
         unsafe {
             ReleaseCapture();
             PostMessageA(hwnd, WM_NCLBUTTONDOWN, HTCAPTION as usize, 0);
@@ -398,16 +395,15 @@ pub fn start_window_drag(window: &Window) {
     }
 }
 
-/// Config GPUI to run without a dock icon on macOS
+/// Promote the macOS process to "accessory" so we live in the menu bar
+/// only — no Dock tile and no Cmd-Tab entry, matching the tray-app UX.
 #[cfg(target_os = "macos")]
 pub fn set_activation_policy_accessory() {
     use objc2::{class, msg_send, runtime::AnyObject};
-    // SAFETY: NSApplication.sharedApplication returns a valid singleton instance that exists
-    // for the lifetime of the application. setActivationPolicy: with argument 1 (NSApplicationActivationPolicyAccessory)
-    // is a standard API call to configure the app as an accessory (no dock icon, no cmd+tab entry).
-    // The msg_send! macro ensures proper ABI compatibility with Objective-C runtime.
+    // SAFETY: `+[NSApplication sharedApplication]` is the canonical
+    // singleton accessor and lives for the whole process; the only
+    // mutation here is the activation-policy flag (1 = Accessory).
     unsafe {
-        // Config the app to be accessory (no dock icon & cmd tab)
         let app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
         let _succeeded: bool = msg_send![app, setActivationPolicy: 1isize];
     }

--- a/src/i18n/error.rs
+++ b/src/i18n/error.rs
@@ -1,6 +1,5 @@
 use thiserror::Error;
 
-/// I18n-related errors.
 #[derive(Debug, Error)]
 pub enum I18nError {
     #[error("Locale file not found: {0}")]

--- a/src/i18n/translations.rs
+++ b/src/i18n/translations.rs
@@ -2,21 +2,21 @@ use std::collections::HashMap;
 
 use super::error::I18nError;
 
-/// Translation keys used throughout the application.
 #[derive(Debug, Clone)]
 pub struct Translations {
     pub(super) strings: HashMap<String, String>,
 }
 
 impl Translations {
-    /// Load translations from a `TOML` string.
     pub fn from_toml(content: &str) -> Result<Self, I18nError> {
         let strings: HashMap<String, String> =
             toml::from_str(content).map_err(|e| I18nError::ParseError(e.to_string()))?;
         Ok(Self { strings })
     }
 
-    /// Get a translated string by key.
+    /// Returns the translation for `key`, or a visible `[Missing: key]`
+    /// placeholder so missing translations surface in the UI instead of
+    /// silently rendering as an empty string.
     pub fn get(&self, key: &str) -> String {
         self.strings
             .get(key)

--- a/src/repository/backend.rs
+++ b/src/repository/backend.rs
@@ -9,57 +9,44 @@ use std::path::PathBuf;
 
 use super::errors::RepositoryError;
 
-/// A named, ordered key-value store that supports forward and reverse
-/// iteration.  Each "tree" in the backend corresponds to a logical
-/// namespace (e.g. `clipboard_records`, `time_index`, `favorites`).
+/// A named, ordered key-value store with forward and reverse iteration.
+/// Each "tree" is a logical namespace (e.g. `clipboard_records`,
+/// `time_index`, `favorites`).
 pub trait KvTree: Send + Sync {
-    /// Insert a key-value pair, overwriting any previous value.
     fn insert(&self, key: &[u8], value: &[u8]) -> Result<(), RepositoryError>;
 
-    /// Get the value associated with a key, if it exists.
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RepositoryError>;
 
-    /// Remove a key-value pair, returning `true` if the key existed.
+    /// Returns `true` if the key existed before removal.
     fn remove(&self, key: &[u8]) -> Result<bool, RepositoryError>;
 
-    /// Return the number of entries in this tree.
     fn len(&self) -> usize;
 
-    /// Remove all entries.
     fn clear(&self) -> Result<(), RepositoryError>;
 
-    /// Iterate over all entries in ascending key order.
-    ///
-    /// The callback returns `true` to continue, `false` to stop.
+    /// Iterate ascending by key. The callback returns `false` to stop early.
     fn scan_ascending(
         &self,
         callback: &mut dyn FnMut(&[u8], &[u8]) -> bool,
     ) -> Result<(), RepositoryError>;
 
-    /// Iterate over all entries in descending key order.
-    ///
-    /// The callback returns `true` to continue, `false` to stop.
+    /// Iterate descending by key. The callback returns `false` to stop early.
     fn scan_descending(
         &self,
         callback: &mut dyn FnMut(&[u8], &[u8]) -> bool,
     ) -> Result<(), RepositoryError>;
 }
 
-/// The top-level storage backend that manages multiple named trees and
-/// database-level operations (flush, schema migration, etc.).
+/// Top-level backend managing multiple [`KvTree`]s and database-level
+/// operations (flush, schema migration, etc.).
 pub trait StorageBackend: Send + Sync {
-    /// Concrete tree handle returned by this backend.
     type Tree: KvTree;
 
-    /// Open (or create) a named tree / namespace.
     fn open_tree(&self, name: &str) -> Result<Self::Tree, RepositoryError>;
 
-    /// Flush all pending writes to durable storage.
     fn flush(&self) -> Result<(), RepositoryError>;
 }
 
-/// Factory function type for creating a [`StorageBackend`] from a path.
-///
-/// Tests provide a factory to [`ClipboardRepository::init`](super::ClipboardRepository::init)
-/// so they can exercise the repository against different storage adapters.
+/// Factory used by [`ClipboardRepository::init`](super::ClipboardRepository::init)
+/// so tests can swap in alternative backends (e.g. the in-memory adapter).
 pub type BackendFactory<B> = fn(&PathBuf) -> Result<B, RepositoryError>;

--- a/src/repository/cleanup.rs
+++ b/src/repository/cleanup.rs
@@ -12,13 +12,14 @@ use super::{
     sidecar::remove_record_sidecars,
 };
 
-/// Allow the repository to grow slightly past the configured limit so cleanup
-/// can batch deletions instead of scanning on every successful save.
+/// Let the repository grow slightly past the configured limit so cleanup can
+/// batch deletions instead of scanning on every successful save.
 const CLEANUP_BUFFER_DIVISOR: usize = 10;
 const MIN_CLEANUP_BUFFER_RECORDS: usize = 1;
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Clear all ordinary records while preserving pinned and favorited ones.
+    /// "Clear history" without losing user-curated records: pinned and
+    /// favorited entries survive.
     pub fn clear_ordinary_records(&self) -> Result<usize, RepositoryError> {
         let total = self.count();
         let favorite_ids = self.favorite_id_set()?;
@@ -27,9 +28,8 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         self.cleanup_old_records_with_ordinary_total(0, ordinary_total, total, &favorite_ids)
     }
 
-    /// Clean up old records, keeping the most recent `keep_count` records.
-    ///
-    /// Pinned records are never removed.
+    /// Trim ordinary records down to the most recent `keep_count`. Pinned
+    /// entries are skipped so users can't lose deliberately-kept records.
     pub fn cleanup_old_records(&self, keep_count: usize) -> Result<usize, RepositoryError> {
         let total = self.count();
         let favorite_ids = self.favorite_id_set()?;
@@ -42,8 +42,10 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         )
     }
 
-    /// Clean up old records only after the repository has exceeded the
-    /// configured limit by a small buffer.
+    /// Hot-path variant of [`Self::cleanup_old_records`]: skip the scan
+    /// until ordinary record count exceeds `keep_count` by the buffer, so
+    /// the common save → cleanup pair doesn't pay for an iteration on
+    /// every insert.
     pub fn cleanup_old_records_if_needed(
         &self,
         keep_count: usize,

--- a/src/repository/errors.rs
+++ b/src/repository/errors.rs
@@ -1,30 +1,21 @@
-//! Repository error types
+//! Repository error types.
 
-/// Errors that can occur during repository operations.
 #[derive(Debug, thiserror::Error)]
 pub enum RepositoryError {
-    /// Data directory not found
     #[error("Data directory not found")]
     DataDirNotFound,
-    /// Database open failed
     #[error("Database open failed: {0}")]
     DatabaseOpen(String),
-    /// Tree open failed
     #[error("Tree open failed: {0}")]
     TreeOpen(String),
-    /// Serialization error
     #[error("Serialization error: {0}")]
     Serialization(String),
-    /// Deserialization error
     #[error("Deserialization error: {0}")]
     Deserialization(String),
-    /// Insert error
     #[error("Insert error: {0}")]
     Insert(String),
-    /// Query error
     #[error("Query error: {0}")]
     Query(String),
-    /// Delete error
     #[error("Delete error: {0}")]
     Delete(String),
 }

--- a/src/repository/favorites.rs
+++ b/src/repository/favorites.rs
@@ -12,7 +12,6 @@ use super::{
 };
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Return all favorite record IDs.
     pub fn favorite_ids(&self) -> Result<Vec<u64>, RepositoryError> {
         let mut ids = Vec::new();
 
@@ -27,9 +26,9 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(ids)
     }
 
-    /// Toggle the favorite state of a record.
-    ///
-    /// Returns the new favorite state after the operation.
+    /// Flip favorite state and return the new value. Errors if the target
+    /// record no longer exists, so the favorites tree can't accumulate
+    /// dangling pointers.
     pub fn toggle_favorite(&self, id: u64) -> Result<bool, RepositoryError> {
         if self.get_by_id(id)?.is_none() {
             return Err(RepositoryError::Query("record not found".to_string()));
@@ -46,13 +45,13 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(true)
     }
 
-    /// Remove a record from favorites.
     pub(super) fn remove_favorite(&self, id: u64) -> Result<(), RepositoryError> {
         self.favorites.remove(&id.to_be_bytes())?;
         Ok(())
     }
 
-    /// Collect all favorite IDs into a `HashSet`, filtering out stale entries.
+    /// Live favorites only: drop ids whose backing record was deleted, so
+    /// callers (cleanup, board rendering) never act on stale favorites.
     pub(super) fn favorite_id_set(&self) -> Result<HashSet<u64>, RepositoryError> {
         let mut favorite_ids = HashSet::new();
 

--- a/src/repository/models.rs
+++ b/src/repository/models.rs
@@ -1,42 +1,39 @@
-//! Data model for clipboard records
+//! Data model for clipboard records.
 
 use std::sync::{Arc, RwLock};
 
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 
-/// Data model for clipboard records
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ClipboardRecord {
-    /// Unique identifier (content hash)
+    /// Content hash; doubles as the deduplication key in the records tree.
     pub id: u64,
-    /// Plain-text clipboard content used for display, search, and deduplication.
+    /// Plain-text payload used for display, search, and dedup. Non-text
+    /// payloads (image, files, rich text) keep their binary data on disk
+    /// via [`RichTextMeta`] / sidecar files and store only a textual
+    /// summary here.
     pub content: String,
-    /// Creation time
     pub created_at: DateTime<Local>,
-    /// Content type
     pub content_type: ContentType,
-    /// Whether this record is pinned to the top
+    /// Pinned records stay at the top of the board and survive cleanup.
     #[serde(default)]
     pub pinned: bool,
-    /// Sidecar metadata for rich text payloads, when present.
     #[serde(default)]
     pub rich_text_meta: Option<RichTextMeta>,
 }
 
-/// Shared clipboard record list type alias for thread-safe access
 pub type SharedRecords = Arc<RwLock<Vec<ClipboardRecord>>>;
 
-/// Content type enumeration
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum ContentType {
-    /// Plain text
     Text,
-    /// Image (stored as `base64`)
+    /// Image payload; the actual bytes live on disk under the per-record
+    /// sidecar directory, and `content` carries the file path.
     Image,
-    /// File path
     FilePath,
-    /// Rich text with plain-text summary plus optional HTML / RTF sidecars.
+    /// Rich text with plain-text summary in `content` plus optional HTML / RTF
+    /// sidecars referenced from [`RichTextMeta`].
     RichText,
 }
 
@@ -47,7 +44,8 @@ pub struct RichTextMeta {
 }
 
 impl ContentType {
-    /// Encode content type as a single byte for the time index.
+    /// One-byte tag used by the time index value format. Stable on disk —
+    /// changing existing variants is a schema migration.
     pub(crate) const fn as_tag(&self) -> u8 {
         match self {
             Self::Text => 0,

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -21,7 +21,8 @@ use crate::{
     utils::{content_hash, normalize_file_paths, serialize_file_paths},
 };
 
-/// Schema version for the database. Bump this when the key format changes.
+/// Bump whenever the on-disk key/value layout changes — a mismatch wipes the
+/// database on startup so stale records can't be misinterpreted.
 const SCHEMA_VERSION: u64 = 3;
 
 pub struct ClipboardRepository<B: StorageBackend = RedbBackend> {
@@ -34,7 +35,6 @@ pub struct ClipboardRepository<B: StorageBackend = RedbBackend> {
 }
 
 impl ClipboardRepository<RedbBackend> {
-    /// Create a new repository backed by redb.
     pub fn new() -> Result<Self, RepositoryError> {
         let db_path = Self::default_db_path()?;
         let images_dir = dirs::data_local_dir()
@@ -53,9 +53,9 @@ impl ClipboardRepository<RedbBackend> {
 }
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Initialize repository with explicit paths and a pluggable backend factory.
-    ///
-    /// Tests use this to inject the in-memory backend while production stays on redb.
+    /// Build a repository against an explicitly chosen backend. Tests use
+    /// this seam to inject the in-memory backend; production goes through
+    /// [`ClipboardRepository::new`].
     pub fn init(
         db_path: &PathBuf,
         images_dir: PathBuf,
@@ -97,7 +97,6 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         })
     }
 
-    /// Flush data to disk.
     pub fn flush(&self) -> Result<(), RepositoryError> {
         self.backend.flush()
     }
@@ -123,10 +122,9 @@ impl<B: StorageBackend> Drop for ClipboardRepository<B> {
 }
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Save a clipboard record.
-    ///
-    /// Uses content hash as the key for deduplication.
-    /// If a record with the same content already exists, only `created_at` is updated.
+    /// Insert or refresh a record keyed by its content hash. A duplicate
+    /// hash bumps `created_at` only — the existing payload is preserved so
+    /// re-copies surface at the top of the board without churning storage.
     pub fn save(
         &self,
         content: String,
@@ -158,10 +156,9 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(record)
     }
 
-    /// Save an image record from an existing file path.
-    ///
-    /// When a duplicate is found the newly saved image file is removed
-    /// and only `created_at` is updated on the existing record.
+    /// Persist an image record whose payload already lives at `file_path`.
+    /// On a duplicate hash the new file is deleted to avoid leaking sidecar
+    /// blobs, and only `created_at` is bumped on the existing record.
     pub fn save_image_from_path(
         &self,
         file_path: String,
@@ -196,12 +193,12 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(record)
     }
 
-    /// Save text content (convenience wrapper).
     pub fn save_text(&self, content: String) -> Result<ClipboardRecord, RepositoryError> {
         self.save(content, ContentType::Text)
     }
 
-    /// Save file list content (convenience wrapper).
+    /// Normalize and persist a file list. Errors when the list is empty so
+    /// callers don't accidentally insert a record with no payload.
     pub fn save_files(&self, paths: &[String]) -> Result<ClipboardRecord, RepositoryError> {
         let normalized = normalize_file_paths(paths);
         if normalized.is_empty() {
@@ -253,7 +250,6 @@ impl<B: StorageBackend> ClipboardRepository<B> {
 }
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Get a record by ID.
     pub fn get_by_id(&self, id: u64) -> Result<Option<ClipboardRecord>, RepositoryError> {
         let key = id.to_be_bytes();
         match self.get_raw(&key)? {
@@ -266,14 +262,12 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         }
     }
 
-    /// Get the total number of records.
     pub fn count(&self) -> usize {
         self.records.len()
     }
 }
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Toggle the pin state of a record.
     pub fn toggle_pin(&self, id: u64) -> Result<(), RepositoryError> {
         let mut record = self
             .get_by_id(id)?
@@ -292,7 +286,6 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(())
     }
 
-    /// Delete a single record.
     pub fn delete(&self, id: u64) -> Result<bool, RepositoryError> {
         let record = self.get_by_id(id)?;
         if let Some(ref rec) = record {
@@ -310,7 +303,7 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(removed)
     }
 
-    /// Clear all records and images.
+    /// Wipe every record and its on-disk sidecars (images + rich text).
     pub fn clear(&self) -> Result<(), RepositoryError> {
         self.records.clear()?;
         self.time_index.clear()?;
@@ -321,12 +314,10 @@ impl<B: StorageBackend> ClipboardRepository<B> {
 }
 
 impl<B: StorageBackend> ClipboardRepository<B> {
-    /// Get raw bytes from the records tree.
     pub(super) fn get_raw(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RepositoryError> {
         self.records.get(key)
     }
 
-    /// Serialize and insert a record into the records tree.
     pub(super) fn put_raw(
         &self,
         key: &[u8],
@@ -337,7 +328,8 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         self.records.insert(key, &value)
     }
 
-    /// Load multiple records by ID, silently skipping failures.
+    /// Load records by id, dropping (with a warn log) any that fail to
+    /// deserialize so a single corrupt entry can't break list rendering.
     pub(super) fn load_records(&self, ids: &[u64]) -> Vec<ClipboardRecord> {
         let mut out = Vec::with_capacity(ids.len());
         for &id in ids {

--- a/src/updater/http.rs
+++ b/src/updater/http.rs
@@ -1,5 +1,6 @@
-//! Shared curl command builder – eliminates duplicated HTTP request logic
-//! across the updater module.
+//! Shared `curl` command builder. Centralises the base flags (silent,
+//! follow redirects, fail on HTTP errors, `User-Agent`) so individual call
+//! sites can't drift apart on retry / timeout policy.
 
 use std::process::Command;
 
@@ -9,15 +10,11 @@ pub const CONNECT_TIMEOUT_SECS: u32 = 15;
 pub const API_REQUEST_MAX_TIME_SECS: u32 = 30;
 pub const DOWNLOAD_REQUEST_MAX_TIME_SECS: u32 = 600;
 
-/// Builder for constructing `curl` subprocess commands with consistent
-/// base arguments (silent, follow redirects, fail on HTTP errors, User-Agent).
 pub struct CurlCommandBuilder {
     command: Command,
 }
 
 impl CurlCommandBuilder {
-    /// Create a new builder with the common base flags: `-sSL --fail` and the
-    /// `User-Agent` header.
     pub fn new(url: &str) -> Self {
         let mut command = Command::new("curl");
         command.args([
@@ -30,40 +27,38 @@ impl CurlCommandBuilder {
         Self { command }
     }
 
-    /// Add an extra HTTP header (e.g. `Accept: application/vnd.github.v3+json`).
     pub fn header(mut self, value: &str) -> Self {
         self.command.args(["-H", value]);
         self
     }
 
-    /// Set the `--connect-timeout` value in seconds.
     pub fn connect_timeout(mut self, seconds: u32) -> Self {
         self.command
             .args(["--connect-timeout", &seconds.to_string()]);
         self
     }
 
-    /// Set the `--max-time` value in seconds.
     pub fn max_time(mut self, seconds: u32) -> Self {
         self.command.args(["--max-time", &seconds.to_string()]);
         self
     }
 
-    /// Apply the standard timeout policy for short-lived API requests.
+    /// Standard policy for short-lived JSON API calls (release listings).
     pub fn with_api_timeouts(self) -> Self {
         self.connect_timeout(CONNECT_TIMEOUT_SECS)
             .max_time(API_REQUEST_MAX_TIME_SECS)
     }
 
-    /// Apply the standard timeout policy for large asset downloads.
+    /// Standard policy for large asset downloads — much longer max-time
+    /// because release archives can run into hundreds of MB.
     pub fn with_download_timeouts(self) -> Self {
         self.connect_timeout(CONNECT_TIMEOUT_SECS)
             .max_time(DOWNLOAD_REQUEST_MAX_TIME_SECS)
     }
 
-    /// Execute the command, collect stdout, and return the body as a `String`.
-    ///
-    /// Logs and returns an `UpdateError::Network` on failure.
+    /// Run to completion and decode stdout as UTF-8. Failures (non-zero
+    /// exit, non-UTF-8 body) are mapped to [`UpdateError::Network`] and
+    /// logged, since every callsite would otherwise repeat the same code.
     pub fn execute_to_string(mut self) -> Result<String, UpdateError> {
         let output = self.command.output().map_err(|e| {
             tracing::error!(error = %e, "failed to launch curl");
@@ -85,8 +80,9 @@ impl CurlCommandBuilder {
         })
     }
 
-    /// Return the inner `Command` for callers that need piped I/O (e.g.
-    /// streaming downloads with progress tracking).
+    /// Escape hatch for callers that need piped stdio (streaming downloads
+    /// with progress tracking) and therefore can't go through
+    /// [`Self::execute_to_string`].
     pub fn into_command(self) -> Command {
         self.command
     }

--- a/src/updater/models.rs
+++ b/src/updater/models.rs
@@ -1,8 +1,9 @@
-//! Data models for auto-update
+//! Data models for auto-update.
 
 use serde::Deserialize;
 
-/// A GitHub Release as returned by the API
+/// Subset of GitHub's Release JSON we actually consume — extra fields are
+/// ignored so upstream additions can't break deserialization.
 #[derive(Debug, Clone, Deserialize)]
 pub struct GitHubRelease {
     pub tag_name: String,
@@ -10,7 +11,6 @@ pub struct GitHubRelease {
     pub assets: Vec<GitHubAsset>,
 }
 
-/// A single asset attached to a GitHub Release
 #[derive(Debug, Clone, Deserialize)]
 pub struct GitHubAsset {
     pub name: String,
@@ -18,7 +18,8 @@ pub struct GitHubAsset {
     pub size: u64,
 }
 
-/// Parsed release information ready for display / download
+/// Release information already resolved to the current target triple, ready
+/// for the UI and the downloader without re-parsing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReleaseInfo {
     pub version: String,
@@ -28,22 +29,18 @@ pub struct ReleaseInfo {
     pub asset_size: u64,
 }
 
-/// Current state of the update lifecycle, shared with the UI
+/// Update lifecycle state shared with the UI as a `Global`. Variants are
+/// observable, hence `PartialEq` for cheap change detection.
 #[derive(Debug, Clone, PartialEq)]
 pub enum UpdateStatus {
-    /// No check has been performed yet
     Idle,
-    /// A version check is in progress
     Checking,
-    /// A newer version is available
     Available(ReleaseInfo),
-    /// The running version is the latest
     UpToDate,
-    /// Downloading the new binary (progress 0.0 – 1.0)
+    /// Download progress in `0.0..=1.0`.
     Downloading(f32),
-    /// The new binary has been written; a restart is needed
+    /// New binary is on disk; user-initiated restart is required to apply it.
     ReadyToRestart,
-    /// An error occurred
     Error(String),
 }
 

--- a/src/utils/single_instance.rs
+++ b/src/utils/single_instance.rs
@@ -13,13 +13,10 @@ pub fn ensure_single_instance() -> bool {
         .chain(std::iter::once(0))
         .collect();
 
-    // SAFETY: CreateMutexW is called with a valid null pointer for security attributes,
-    // zero for initial owner (not owned), and a null-terminated wide string for the mutex name.
-    // The mutex name is valid UTF-16 with null terminator. GetLastError is safe to call anytime.
-    // FindWindowW is called with a valid null-terminated class name and null window name,
-    // which searches for any window of the specified class. ShowWindow and SetForegroundWindow
-    // are safe to call with any window handle; they may fail silently if the handle is invalid
-    // or the operation is not permitted, but will not cause undefined behavior.
+    // SAFETY: every wide string passed in is null-terminated; window
+    // handles returned by `FindWindowW` are only used while this stack
+    // frame is live, so neither `ShowWindow` nor `SetForegroundWindow`
+    // can outlive them.
     unsafe {
         let mutex = CreateMutexW(std::ptr::null(), 0, wide_name.as_ptr());
         if mutex.is_null() {
@@ -27,7 +24,9 @@ pub fn ensure_single_instance() -> bool {
         }
 
         if GetLastError() == ERROR_ALREADY_EXISTS {
-            // Try to activate existing window
+            // GPUI registers its Win32 windows under the `Zed::Window`
+            // class name; matching that lets us bring the existing
+            // instance to the foreground instead of silently exiting.
             let class_name = OsStr::new("Zed::Window")
                 .encode_wide()
                 .chain(std::iter::once(0))


### PR DESCRIPTION
## Summary
Repository-wide comment audit driven by Clean Code's "explain *why*, not *what*" principle. Drops stale, dangling, and signature-restating comments; compresses verbose `SAFETY:` blocks; preserves every module-level `//!` doc and *why* comment that pulls its weight.

## Linked Issue
Closes #76

## Changes
- **Stale / wrong / dangling notes (P0)**
  - `repository/models.rs`: drop the `Image (stored as base64)` doc that contradicts the current sidecar storage path; tighten `ContentType` and `ClipboardRecord` field docs to the few that actually add context.
  - `gui/board/preview.rs`: promote a `///` floating between two `use` statements into a real module `//!` doc.
  - `gui/board/hotkey_record_handler.rs`: remove the `merged from gui/hotkey_record.rs` historical marker (git history covers it).
- **Signature-restating docs (P1)** stripped across `repository/{errors, backend, repo, favorites, cleanup}.rs`, `updater/{models, http}.rs`, `i18n/{error, translations}.rs`, `gui/board/{record_ops, settings_editor, clear_confirm, header, filtering, updater_ui}.rs`, `gui/panel/{about, help, settings}.rs`, `gui/{tray, theme}.rs`, `clipboard/writer.rs`, `config/settings/mod.rs`, and `constants.rs`. Where the *why* matters (dedup behavior, sidecar lifetime, validation contract, cleanup-buffer rationale, etc.) the doc is rewritten to state it.
- **Boilerplate / verbosity (P2)**
  - `gui/utils.rs`: introduce a module-level `//!` capturing the SAFETY invariants shared across all 11 Win32 blocks; per-block `// SAFETY:` notes now only call out block-specific deltas.
  - `utils/single_instance.rs`: SAFETY block compressed; add a *why* note explaining the `Zed::Window` magic class name (GPUI's Win32 class).
  - `config/autostart.rs`: drop `# Arguments` / `# Returns` rustdoc templates; rewrite `get_app_path` and `sync_state` docs to explain the `.app`-bundle constraint and the no-op-when-equal rationale.
  - `gui/board/preview.rs`: drop `# Usage Example` blocks.
  - `clipboard/writer.rs`: tighten the macOS race-condition note.
  - `constants.rs`: replace the historical narrative with a one-line module doc; expand `SILENT_ARG` to explain *why* it exists.
- **Inline standalone markers (P3)** in `app.rs`'s `launch()` collapsed; the genuinely helpful ordering / dependency notes (Settings before I18n, tray needs I18n) survive in concise form.

Behavior is unchanged — comments only.

## Testing
- [x] `scripts/precheck.sh` passes locally (`cargo check`, `cargo clippy -D warnings`, **421 tests passed**, `cargo machete`, `check_i18n.py`, `check_icons.py`, `check_themes.py`)
- [x] No new lints reported by the IDE on the 30 modified files.
