### PR TITLE
refactor: replace global clippy::pedantic allows with local annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,13 +93,6 @@ expect_used = "warn"
 print_stdout = "warn"
 print_stderr = "warn"
 undocumented_unsafe_blocks = "warn"
-module_name_repetitions = "allow"
-cast_possible_truncation = "allow"
-cast_precision_loss = "allow"
-cast_sign_loss = "allow"
-missing_errors_doc = "allow"
-missing_panics_doc = "allow"
-derive_partial_eq_without_eq = "allow"
 
 [profile.release]
 opt-level = 3

--- a/src/gui/board/actions.rs
+++ b/src/gui/board/actions.rs
@@ -23,21 +23,29 @@ impl RopyBoard {
     }
 }
 
-gpui::actions!(
-    board,
-    [
-        Hide,
-        Quit,
-        Active,
-        SelectLeft,
-        SelectRight,
-        SelectPrev,
-        SelectNext,
-        ConfirmSelection,
-        ConfirmSelectionPlainText,
-        DeleteRecord
-    ]
-);
+#[allow(
+    clippy::derive_partial_eq_without_eq,
+    reason = "gpui::actions! macro generates PartialEq; we cannot inject Eq from outside"
+)]
+mod generated_actions {
+    gpui::actions!(
+        board,
+        [
+            Hide,
+            Quit,
+            Active,
+            SelectLeft,
+            SelectRight,
+            SelectPrev,
+            SelectNext,
+            ConfirmSelection,
+            ConfirmSelectionPlainText,
+            DeleteRecord
+        ]
+    );
+}
+
+pub use generated_actions::*;
 
 pub(super) fn horizontal_grid_target_index(
     selected_index: usize,

--- a/src/gui/board/color.rs
+++ b/src/gui/board/color.rs
@@ -206,7 +206,13 @@ fn parse_alpha(value: &str) -> Option<u8> {
         return None;
     }
 
-    Some((alpha * 255.0).round() as u8)
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "guard above pins alpha to [0.0, 1.0] so the scaled value fits in u8"
+    )]
+    let byte = (alpha * 255.0).round() as u8;
+    Some(byte)
 }
 
 fn hsl_to_rgb(hue: f32, saturation: f32, lightness: f32) -> (u8, u8, u8) {
@@ -237,6 +243,11 @@ fn hsl_to_rgb(hue: f32, saturation: f32, lightness: f32) -> (u8, u8, u8) {
     )
 }
 
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "clamp(0.0, 1.0) keeps the scaled value in [0.0, 255.0]"
+)]
 fn float_channel_to_u8(value: f32) -> u8 {
     (value.clamp(0.0, 1.0) * 255.0).round() as u8
 }

--- a/src/gui/board/preview.rs
+++ b/src/gui/board/preview.rs
@@ -82,8 +82,11 @@ fn calculate_image_size(
     if let Ok(reader) = ImageReader::open(path).and_then(image::ImageReader::with_guessed_format)
         && let Ok(dims) = reader.into_dimensions()
     {
-        let w = dims.0 as f32;
-        let h = dims.1 as f32;
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "image dimensions in pixels are well below the f32 mantissa range"
+        )]
+        let (w, h) = (dims.0 as f32, dims.1 as f32);
 
         let width_ratio = Into::<f32>::into(max_w) / w;
         let height_ratio = Into::<f32>::into(max_h) / h;

--- a/src/gui/board/records_list/masonry.rs
+++ b/src/gui/board/records_list/masonry.rs
@@ -7,7 +7,7 @@ use gpui_component::scroll::{Scrollbar, ScrollbarShow};
 
 use super::{
     SCROLLBAR_OVERLAY_RIGHT_OFFSET,
-    metrics::{GRID_COLUMN_COUNT, estimated_grid_card_height},
+    metrics::{GRID_COLUMN_COUNT, GRID_COLUMN_COUNT_F32, estimated_grid_card_height},
     row::{RecordsListState, render_list_item_with_grid_height},
 };
 use crate::utils::read_or_recover;
@@ -54,6 +54,10 @@ fn build_masonry_layout(
             .map_or(0, |(column, _)| column);
 
         let top = column_heights[column];
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "column index is bounded by column_count (typically 2-4)"
+        )]
         let left = column as f32 * (column_width + column_gap);
         column_heights[column] += height + row_gap;
 
@@ -83,7 +87,7 @@ pub(super) fn grid_available_width(window: &Window) -> gpui::Pixels {
 }
 
 fn grid_card_width(available_width: gpui::Pixels) -> gpui::Pixels {
-    ((available_width - px(GRID_COLUMN_GAP)) / GRID_COLUMN_COUNT as f32).max(px(1.0))
+    ((available_width - px(GRID_COLUMN_GAP)) / GRID_COLUMN_COUNT_F32).max(px(1.0))
 }
 
 fn masonry_visible_window(scroll_handle: &ScrollHandle, window: &Window) -> (f32, f32) {

--- a/src/gui/board/records_list/metrics.rs
+++ b/src/gui/board/records_list/metrics.rs
@@ -8,6 +8,12 @@ use crate::{
 };
 
 pub(super) const GRID_COLUMN_COUNT: usize = 2;
+// Mirror constant in `f32` form so masonry layout math avoids per-call casts.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "GRID_COLUMN_COUNT is a tiny compile-time literal"
+)]
+pub(super) const GRID_COLUMN_COUNT_F32: f32 = GRID_COLUMN_COUNT as f32;
 pub(super) const GRID_CONTENT_PREVIEW_LIMIT: usize = 96;
 pub(super) const GRID_CONTENT_PREVIEW_MAX_LINES: usize = 4;
 pub(super) const GRID_CARD_MIN_HEIGHT: f32 = 96.0;
@@ -126,9 +132,15 @@ fn estimated_wrapped_line_count(content: &str, max_lines: usize) -> usize {
             if line.is_empty() {
                 1
             } else {
-                (estimated_text_units(line) / GRID_ESTIMATED_TEXT_LINE_WIDTH_UNITS)
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_sign_loss,
+                    reason = ".max(1.0) keeps the value in [1.0, max_lines), well within usize"
+                )]
+                let lines = (estimated_text_units(line) / GRID_ESTIMATED_TEXT_LINE_WIDTH_UNITS)
                     .ceil()
-                    .max(1.0) as usize
+                    .max(1.0) as usize;
+                lines
             }
         })
         .sum::<usize>();
@@ -148,10 +160,13 @@ pub(super) fn estimated_grid_text_lines(content: &str) -> usize {
 }
 
 pub(super) fn estimated_grid_color_body_height(content: &str) -> f32 {
-    GRID_ESTIMATED_TEXT_LINE_HEIGHT.mul_add(
-        estimated_grid_text_lines(content) as f32,
-        GRID_COLOR_SWATCH_HEIGHT + GRID_COLOR_SWATCH_GAP,
-    )
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "line count is bounded by GRID_CONTENT_PREVIEW_MAX_LINES (4)"
+    )]
+    let line_count = estimated_grid_text_lines(content) as f32;
+    GRID_ESTIMATED_TEXT_LINE_HEIGHT
+        .mul_add(line_count, GRID_COLOR_SWATCH_HEIGHT + GRID_COLOR_SWATCH_GAP)
 }
 
 pub(super) fn file_display_name(path: &str) -> String {
@@ -195,14 +210,24 @@ pub(super) fn estimated_grid_card_height(record: &ClipboardRecord) -> f32 {
             if parse_clipboard_color(&record.content).is_some() {
                 estimated_grid_color_body_height(&record.content)
             } else {
-                estimated_grid_text_lines(&record.content) as f32 * GRID_ESTIMATED_TEXT_LINE_HEIGHT
+                #[allow(
+                    clippy::cast_precision_loss,
+                    reason = "line count is bounded by GRID_CONTENT_PREVIEW_MAX_LINES (4)"
+                )]
+                let lines = estimated_grid_text_lines(&record.content) as f32;
+                lines * GRID_ESTIMATED_TEXT_LINE_HEIGHT
             }
         }
         ContentType::Image => GRID_IMAGE_MAX_HEIGHT,
-        ContentType::FilePath => GRID_ESTIMATED_FILE_DETAIL_LINE_HEIGHT.mul_add(
-            estimated_grid_file_detail_lines(&record.content) as f32,
-            GRID_ESTIMATED_FILE_TITLE_HEIGHT,
-        ),
+        ContentType::FilePath => {
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "detail line count is bounded by GRID_CONTENT_PREVIEW_MAX_LINES - 1"
+            )]
+            let detail_lines = estimated_grid_file_detail_lines(&record.content) as f32;
+            GRID_ESTIMATED_FILE_DETAIL_LINE_HEIGHT
+                .mul_add(detail_lines, GRID_ESTIMATED_FILE_TITLE_HEIGHT)
+        }
     };
 
     (GRID_ESTIMATED_CARD_CHROME_HEIGHT + body_height)
@@ -287,10 +312,13 @@ mod tests {
     #[test]
     fn test_estimated_grid_color_body_height_adds_large_swatch_space() {
         let content = "#A1B2C3";
-        let expected = GRID_ESTIMATED_TEXT_LINE_HEIGHT.mul_add(
-            estimated_grid_text_lines(content) as f32,
-            GRID_COLOR_SWATCH_HEIGHT + GRID_COLOR_SWATCH_GAP,
-        );
+        #[allow(
+            clippy::cast_precision_loss,
+            reason = "line count is bounded by GRID_CONTENT_PREVIEW_MAX_LINES (4)"
+        )]
+        let lines = estimated_grid_text_lines(content) as f32;
+        let expected = GRID_ESTIMATED_TEXT_LINE_HEIGHT
+            .mul_add(lines, GRID_COLOR_SWATCH_HEIGHT + GRID_COLOR_SWATCH_GAP);
 
         assert!((estimated_grid_color_body_height(content) - expected).abs() < f32::EPSILON);
     }

--- a/src/gui/board/settings_editor.rs
+++ b/src/gui/board/settings_editor.rs
@@ -115,6 +115,11 @@ pub(super) fn build_window_opacity_slider(
         window,
         |this, _, event: &SliderEvent, window, cx| {
             let SliderEvent::Change(value) = event;
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "slider value is bounded by MIN/MAX_OPACITY_PERCENT (0..=100)"
+            )]
             let opacity_percent = value.start().round() as u8;
             this.settings_editor.window_opacity_percent = opacity_percent;
             let theme = ThemeId::all()

--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -127,8 +127,16 @@ fn calculate_activation_window_geometry(
     } else {
         1.0
     };
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "physical pixel sizes fit in i32 on every supported platform"
+    )]
     let client_width =
         ((Into::<f32>::into(logical_size.width) * scale_factor).round() as i32).max(1);
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "physical pixel sizes fit in i32 on every supported platform"
+    )]
     let client_height =
         ((Into::<f32>::into(logical_size.height) * scale_factor).round() as i32).max(1);
     let width = client_width + frame_extents.left + frame_extents.right;

--- a/src/repository/time_index.rs
+++ b/src/repository/time_index.rs
@@ -232,6 +232,12 @@ impl<T: KvTree> TimeIndex<T> {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    reason = "test fixtures use small loop indices that fit in any integer width"
+)]
 mod tests {
     use std::collections::HashSet;
 

--- a/src/updater/downloader.rs
+++ b/src/updater/downloader.rs
@@ -109,6 +109,10 @@ fn download_file(
         std::io::Write::write_all(&mut file, &buf[..n]).map_err(UpdateError::Io)?;
         downloaded += n as u64;
         if total_size > 0 {
+            #[allow(
+                clippy::cast_precision_loss,
+                reason = "download progress only needs sub-percent accuracy"
+            )]
             let progress = downloaded as f32 / total_size as f32;
             let _ = progress_tx.send_blocking(progress);
         }

--- a/src/updater/models.rs
+++ b/src/updater/models.rs
@@ -20,7 +20,7 @@ pub struct GitHubAsset {
 
 /// Release information already resolved to the current target triple, ready
 /// for the UI and the downloader without re-parsing.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseInfo {
     pub version: String,
     pub release_notes: String,

--- a/src/utils/clipboard_files.rs
+++ b/src/utils/clipboard_files.rs
@@ -1,3 +1,12 @@
+const fn hex_digit_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn decode_percent_encoded(input: &str) -> String {
     let bytes = input.as_bytes();
     let mut index = 0;
@@ -5,11 +14,11 @@ fn decode_percent_encoded(input: &str) -> String {
 
     while index < bytes.len() {
         if bytes[index] == b'%' && index + 2 < bytes.len() {
-            let high = (bytes[index + 1] as char).to_digit(16);
-            let low = (bytes[index + 2] as char).to_digit(16);
+            let high = hex_digit_value(bytes[index + 1]);
+            let low = hex_digit_value(bytes[index + 2]);
 
             if let (Some(high), Some(low)) = (high, low) {
-                decoded.push(((high << 4) | low) as u8);
+                decoded.push((high << 4) | low);
                 index += 3;
                 continue;
             }


### PR DESCRIPTION
## Summary

Replace seven blanket `clippy::pedantic` allows in `Cargo.toml` with localized `#[allow(...)]` annotations (each carrying a `reason = "..."`), and remove a few warnings entirely at the source. After this change `cargo clippy --all-targets --all-features -- -D warnings` is clean.

## Linked Issue

Closes #78

## Changes

- **`Cargo.toml`** — drop the seven global `clippy::pedantic` allows so future code is lint-checked again.
- **Source-level fixes (no `#[allow]` left behind)**:
  - `utils::clipboard_files` — new `hex_digit_value(u8) -> Option<u8>` helper keeps percent-decoding in `u8` end-to-end, eliminating the `u32 -> u8` cast and the misleading `try_from` clippy suggestion.
  - `updater::models` — derive `Eq` on `ReleaseInfo` (`UpdateStatus` keeps `PartialEq` only because it carries an `f32` progress value).
  - `gui::board::records_list::metrics` — add `GRID_COLUMN_COUNT_F32` mirror constant so masonry layout math no longer casts at runtime.
- **Localized `#[allow(... reason = "...")]`** for the remaining warnings, each documenting the safety invariant at that exact site:
  - `gui::board::color` — `parse_alpha` and `float_channel_to_u8` are guarded to `[0.0, 1.0]` before scaling to `u8`.
  - `gui::board::preview` — image dimensions from the `image` crate fit comfortably in `f32`.
  - `gui::board::records_list::metrics` / `masonry` — line counts and column indices are bounded by small compile-time constants.
  - `gui::board::settings_editor` — opacity slider is bounded by `MIN/MAX_OPACITY_PERCENT` (0..=100).
  - `gui::utils` — physical pixel sizes fit in `i32` on every supported platform.
  - `updater::downloader` — download progress only needs sub-percent accuracy.
  - `gui::board::actions` — `gpui::actions!` macro can't have `Eq` injected from outside; the generated items are wrapped in a private submodule scoped with `#[allow(derive_partial_eq_without_eq)]` and re-exported, so external usage is unchanged.
  - `repository::time_index` (tests only) — module-level allow for cast lints over small loop indices used in test fixtures.

## Testing

- [x] `scripts/precheck.sh` passes locally (`cargo fmt`, `cargo check`, `cargo clippy -- -D warnings`, `cargo test` 421 passed, `cargo machete`, i18n / icons / themes checks)
- [x] No new tests needed — refactor is purely mechanical, no behavior change
