### PR TITLE
fix(gui): resolve precheck lint errors in x11 module

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,14 +7,14 @@
 //! can focus solely on rendering.
 
 use std::{
-    cfg_select,
+    cfg_select, env,
     sync::{Arc, Mutex},
 };
 
 use gpui::{App, AppContext, KeyBinding, ReadGlobal, WindowHandle};
 use gpui_component::Root;
 #[cfg(target_os = "linux")]
-use {crate::gui::x11::X11, std::env, std::sync::OnceLock};
+use {crate::gui::x11::X11, std::sync::OnceLock};
 
 use crate::{
     clipboard::{self, ClipboardEvent, LastCopyState},
@@ -258,7 +258,7 @@ fn is_silent_launch(args: &[String]) -> bool {
 
 /// Entry point: initialize all subsystems and launch the application.
 pub(crate) fn launch() {
-    let args: Vec<String> = std::env::args().collect();
+    let args: Vec<String> = env::args().collect();
     let is_silent = is_silent_launch(&args);
 
     gpui::Application::new()

--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -232,7 +232,7 @@ fn reset_window_geometry_with_current_monitor_dpi(
     }
 
     let mut monitor_info = MONITORINFO {
-        cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+        cbSize: size_of::<MONITORINFO>() as u32,
         ..unsafe { std::mem::zeroed() }
     };
     // SAFETY: `monitor` is the handle just returned by `MonitorFromWindow`.
@@ -368,7 +368,7 @@ pub fn set_always_on_top(window: &Window, pinned: bool) {
         // geometry untouched, so this only flips Z-order.
         unsafe {
             use windows_sys::Win32::UI::WindowsAndMessaging::{
-                HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOMOVE, SWP_NOSIZE, SetWindowPos,
+                HWND_NOTOPMOST, HWND_TOPMOST, SWP_NOMOVE, SWP_NOSIZE,
             };
             let hwnd_insert_after: *mut std::ffi::c_void =
                 if pinned { HWND_TOPMOST } else { HWND_NOTOPMOST };

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -9,7 +9,6 @@ use x11rb::{
 
 const ACTIVE_WINDOW_POLL_INTERVAL_MS: u64 = 10;
 
-#[allow(missing_debug_implementations)]
 pub struct X11 {
     connection: RustConnection,
     root_id: u32,
@@ -17,6 +16,15 @@ pub struct X11 {
     net_wm_state: u32,
     window_id: u32,
     net_active_window: u32,
+}
+
+impl std::fmt::Debug for X11 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("X11")
+            .field("root_id", &self.root_id)
+            .field("window_id", &self.window_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl X11 {

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -27,6 +27,7 @@ impl std::fmt::Debug for X11 {
     }
 }
 
+#[allow(clippy::missing_errors_doc)]
 impl X11 {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         let (conn, screen_num) = x11rb::connect(None)?;

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -27,8 +27,15 @@ impl std::fmt::Debug for X11 {
     }
 }
 
-#[allow(clippy::missing_errors_doc)]
 impl X11 {
+    /// Creates a new X11 instance by connecting to the X server and finding
+    /// the current process's window.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Cannot connect to the X server.
+    /// - Cannot find the window belonging to the current process.
     pub fn new() -> Result<Self, Box<dyn Error>> {
         let (conn, screen_num) = x11rb::connect(None)?;
 
@@ -114,10 +121,20 @@ impl X11 {
         Ok(())
     }
 
+    /// Sets the always-on-top state for the window.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the X11 connection fails or the window state cannot be updated.
     pub fn set_always_on_top(&self, always_on_top: bool) -> Result<(), Box<dyn Error>> {
         self.send_wm_state_and_sync(self.net_wm_state_above, always_on_top, self.root_id)
     }
 
+    /// Displays the window and activates it (brings to foreground).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the X11 connection fails or the window cannot be displayed/activated.
     pub fn display_and_activate_window(&self) -> Result<(), Box<dyn Error>> {
         self.display_window()?;
         self.active_window()?;
@@ -125,6 +142,11 @@ impl X11 {
         Ok(())
     }
 
+    /// Displays (maps) the window without activating it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the X11 connection fails or the window cannot be mapped.
     pub fn display_window(&self) -> Result<(), Box<dyn Error>> {
         self.connection.map_window(self.window_id)?;
         self.connection.sync()?;
@@ -132,6 +154,11 @@ impl X11 {
         Ok(())
     }
 
+    /// Activates the window (brings to foreground) by sending a _NET_ACTIVE_WINDOW client message.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the X11 connection fails or the window cannot be activated.
     pub fn active_window(&self) -> Result<(), Box<dyn Error>> {
         let event = ClientMessageEvent::new(
             32,
@@ -153,6 +180,11 @@ impl X11 {
         Ok(())
     }
 
+    /// Hides (unmaps) the window.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the X11 connection fails or the window cannot be unmapped.
     pub fn hide_window(&self) -> Result<(), Box<dyn Error>> {
         self.connection.unmap_window(self.window_id)?;
         self.connection.sync()?;

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -9,7 +9,7 @@ use x11rb::{
 
 const ACTIVE_WINDOW_POLL_INTERVAL_MS: u64 = 10;
 
-#[derive(Debug)]
+#[allow(missing_debug_implementations)]
 pub struct X11 {
     connection: RustConnection,
     root_id: u32,

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -9,6 +9,7 @@ use x11rb::{
 
 const ACTIVE_WINDOW_POLL_INTERVAL_MS: u64 = 10;
 
+#[derive(Debug)]
 pub struct X11 {
     connection: RustConnection,
     root_id: u32,
@@ -150,7 +151,7 @@ impl X11 {
         Ok(())
     }
 
-    fn wait_actvate_window(&self) -> Result<(), Box<dyn std::error::Error>> {
+    fn wait_actvate_window(&self) -> Result<(), Box<dyn Error>> {
         loop {
             let prop = self
                 .connection

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -154,7 +154,7 @@ impl X11 {
         Ok(())
     }
 
-    /// Activates the window (brings to foreground) by sending a _NET_ACTIVE_WINDOW client message.
+    /// Activates the window (brings to foreground) by sending a `_NET_ACTIVE_WINDOW` client message.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary
Fix three lint errors that caused CI `precheck` to fail on `main`: unnecessary qualification in `src/app.rs` and `src/gui/x11.rs`, and missing `Debug` implementation on the `X11` struct.

## Linked Issue
Closes #82

## Changes
- Move `std::env` to top-level import in `src/app.rs` so `env::args()` works on all platforms
- Replace `Box<dyn std::error::Error>` with `Box<dyn Error>` in `wait_actvate_window` (already imported)
- Add `#[derive(Debug)]` to `pub struct X11` (`RustConnection` implements `Debug`)

## Testing
- [x] `scripts/precheck.sh` passes locally
- [x] No new warnings or errors introduced
