### PR TITLE
fix(gui): improve about panel text contrast under transparent dark themes

### DIFF
--- a/src/gui/panel/about.rs
+++ b/src/gui/panel/about.rs
@@ -91,7 +91,7 @@ pub(crate) fn render_about_content(
                     .px_8()
                     .text_center()
                     .text_sm()
-                    .text_color(cx.theme().muted_foreground)
+                    .text_color(cx.theme().foreground)
                     .child(I18n::translate(cx, "about_description")),
             )
             // License
@@ -157,10 +157,12 @@ fn render_update_section(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl
             friendly_msg.into()
         }
     };
+    // Use `foreground` for every non-error status so the text stays legible
+    // under dark themes when the window is in transparent mode, where
+    // `muted_foreground` blends into the translucent background.
     let status_color = match &board.update_manager.status {
-        UpdateStatus::Available(_) | UpdateStatus::ReadyToRestart => cx.theme().foreground,
         UpdateStatus::Error(_) => gpui::rgb(0x00cc_3333).into(),
-        _ => cx.theme().muted_foreground,
+        _ => cx.theme().foreground,
     };
 
     let action_button: Option<Button> = match &board.update_manager.status {


### PR DESCRIPTION
## Summary
Improve text contrast on the About panel under transparent dark themes by switching the description and muted-state update status text from `theme.muted_foreground` to `theme.foreground`.

## Linked Issue
Closes #90

## Changes
- `src/gui/panel/about.rs`: description text now uses `cx.theme().foreground`.
- `src/gui/panel/about.rs`: update status text uses `cx.theme().foreground` for all non-error states (`Idle / Checking / UpToDate / Downloading / Available / ReadyToRestart`); `Error` keeps its red color.

## Testing
- [x] `scripts/precheck.sh` passes locally (clippy clean, 421 tests passed, i18n / icons / themes checks all OK)
- [x] No new tests added: this is a pure visual color swap with no logic change
