### PR TITLE
refactor(repository): move backend implementations into backend/ submodule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 
 ## Development
 
+- Follow all the best practices outlined in the clippy lint.
 - Define all error types with `thiserror` — avoid manual `impl Display/Error`.
 - Build new UI components using `gpui-component`.
 - Run `scripts/precheck.sh` before committing to verify code quality and formatting.

--- a/src/app.rs
+++ b/src/app.rs
@@ -341,7 +341,7 @@ mod tests {
     use std::{thread, time::Duration};
 
     use super::*;
-    use crate::repository::memory_backend::{MemoryBackend, memory_backend_factory};
+    use crate::repository::backend::memory::{MemoryBackend, memory_backend_factory};
 
     fn create_test_repo() -> (tempfile::TempDir, ClipboardRepository<MemoryBackend>) {
         let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_load_initial_records_when_repository_is_missing_returns_empty() {
         let records =
-            load_initial_records::<crate::repository::redb_backend::RedbBackend>(None, 10);
+            load_initial_records::<crate::repository::backend::redb::RedbBackend>(None, 10);
 
         assert!(records.is_empty());
     }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -2,20 +2,15 @@ use std::sync::Arc;
 
 use gpui::{App, Global, ReadGlobal};
 
-/// Storage backend traits shared by repository implementations.
+/// Storage backend traits and implementations (memory, redb).
 pub mod backend;
 mod cleanup;
 mod display;
 /// Repository error types.
 pub mod errors;
 mod favorites;
-#[cfg(test)]
-/// In-memory backend used by tests.
-pub mod memory_backend;
 /// Persisted clipboard record models.
 pub mod models;
-/// Production `redb` backend implementation.
-pub mod redb_backend;
 /// Repository entry points and persistence APIs.
 pub mod repo;
 mod sidecar;

--- a/src/repository/backend.rs
+++ b/src/repository/backend.rs
@@ -9,6 +9,10 @@ use std::path::PathBuf;
 
 use super::errors::RepositoryError;
 
+#[cfg(test)]
+pub mod memory;
+pub mod redb;
+
 /// A named, ordered key-value store with forward and reverse iteration.
 /// Each "tree" is a logical namespace (e.g. `clipboard_records`,
 /// `time_index`, `favorites`).

--- a/src/repository/backend/memory.rs
+++ b/src/repository/backend/memory.rs
@@ -8,7 +8,7 @@ use std::{
     sync::{Arc, LockResult, Mutex, PoisonError, RwLock},
 };
 
-use super::{
+use crate::repository::{
     backend::{KvTree, StorageBackend},
     errors::RepositoryError,
 };

--- a/src/repository/backend/redb.rs
+++ b/src/repository/backend/redb.rs
@@ -15,7 +15,7 @@ use std::{
 
 use redb::{Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition};
 
-use super::{
+use crate::repository::{
     backend::{KvTree, StorageBackend},
     errors::RepositoryError,
 };

--- a/src/repository/cleanup.rs
+++ b/src/repository/cleanup.rs
@@ -4,10 +4,9 @@
 use std::collections::HashSet;
 
 use super::{
-    backend::{KvTree, StorageBackend},
+    backend::{KvTree, StorageBackend, redb::RedbBackend},
     errors::RepositoryError,
     models::ClipboardRecord,
-    redb_backend::RedbBackend,
     repo::ClipboardRepository,
     sidecar::remove_record_sidecars,
 };

--- a/src/repository/display.rs
+++ b/src/repository/display.rs
@@ -3,8 +3,10 @@
 use std::cmp::Ordering;
 
 use super::{
-    backend::StorageBackend, errors::RepositoryError, models::ClipboardRecord,
-    redb_backend::RedbBackend, repo::ClipboardRepository,
+    backend::{StorageBackend, redb::RedbBackend},
+    errors::RepositoryError,
+    models::ClipboardRecord,
+    repo::ClipboardRepository,
 };
 
 impl<B: StorageBackend> ClipboardRepository<B> {

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -6,10 +6,12 @@ use std::path::{Path, PathBuf};
 use chrono::Local;
 
 use super::{
-    backend::{BackendFactory, KvTree, StorageBackend},
+    backend::{
+        BackendFactory, KvTree, StorageBackend,
+        redb::{RedbBackend, redb_backend_factory},
+    },
     errors::RepositoryError,
     models::{ClipboardRecord, ContentType},
-    redb_backend::{RedbBackend, redb_backend_factory},
     sidecar::{
         purge_sidecar_dirs, remove_image_files, remove_record_sidecars,
         remove_superseded_rich_text_files,

--- a/src/repository/test_helpers.rs
+++ b/src/repository/test_helpers.rs
@@ -6,8 +6,10 @@ use std::{thread, time::Duration};
 use tempfile::tempdir;
 
 use super::{
-    backend::{BackendFactory, StorageBackend},
-    memory_backend::{MemoryBackend, memory_backend_factory},
+    backend::{
+        BackendFactory, StorageBackend,
+        memory::{MemoryBackend, memory_backend_factory},
+    },
     models::ClipboardRecord,
     repo::ClipboardRepository,
 };

--- a/src/repository/tests/dedup_tests.rs
+++ b/src/repository/tests/dedup_tests.rs
@@ -6,9 +6,9 @@ use std::{thread, time::Duration};
 use rstest::rstest;
 
 use crate::repository::{
-    backend::{BackendFactory, StorageBackend},
-    memory_backend::memory_backend_factory,
-    redb_backend::redb_backend_factory,
+    backend::{
+        BackendFactory, StorageBackend, memory::memory_backend_factory, redb::redb_backend_factory,
+    },
     repo::ClipboardRepository,
     test_helpers::{
         create_test_repo, create_test_repo_with, load_display_records, save_numbered_records,

--- a/src/repository/tests/save_tests.rs
+++ b/src/repository/tests/save_tests.rs
@@ -5,10 +5,10 @@
 use std::{thread, time::Duration};
 
 use crate::repository::{
-    backend::{BackendFactory, StorageBackend},
-    memory_backend::memory_backend_factory,
+    backend::{
+        BackendFactory, StorageBackend, memory::memory_backend_factory, redb::redb_backend_factory,
+    },
     models::{ClipboardRecord, ContentType},
-    redb_backend::redb_backend_factory,
     test_helpers::{create_test_repo, create_test_repo_with},
 };
 

--- a/src/repository/time_index.rs
+++ b/src/repository/time_index.rs
@@ -241,10 +241,10 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::repository::{
-        backend::{BackendFactory, StorageBackend},
-        memory_backend::{MemoryTreeHandle, memory_backend_factory},
-        redb_backend::redb_backend_factory,
+    use crate::repository::backend::{
+        BackendFactory, StorageBackend,
+        memory::{MemoryTreeHandle, memory_backend_factory},
+        redb::redb_backend_factory,
     };
 
     type MemoryTimeIndex = TimeIndex<MemoryTreeHandle>;


### PR DESCRIPTION
## Summary
Reorganize the repository backend implementations by moving `memory_backend.rs` and `redb_backend.rs` into the `backend/` submodule, alongside the trait definitions they implement. Also adds a clippy best-practices note to AGENTS.md.

## Linked Issue
Closes #94

## Changes
- Move `memory_backend.rs` → `backend/memory.rs` (test-only)
- Move `redb_backend.rs` → `backend/redb.rs` (production)
- Update all import paths across 9 files
- Unify import style in moved files to use absolute paths
- Update `AGENTS.md` with clippy best-practices note

## Testing
- [x] `scripts/precheck.sh` passes locally (build, clippy, 426 tests, i18n, icons, themes)
- [x] No unused dependencies detected (cargo-machete)
