### PR TITLE
docs: simplify contribution flow skill and clean up issue template

### DIFF
--- a/.agents/skills/ropy-contribution-flow/SKILL.md
+++ b/.agents/skills/ropy-contribution-flow/SKILL.md
@@ -1,65 +1,51 @@
 ---
 name: ropy-contribution-flow
-description: Standard operating procedure for contributing changes to the Ropy repository. Use whenever the user asks to implement, fix, refactor, or otherwise modify code in this repo — anything that should end up as a commit. Drives the full Issue → Branch → PR → Squash Merge flow with the local `gh` CLI, using the project's templates, Conventional Commits rules, and `scripts/precheck.sh` gate. Triggers on phrases like "add feature", "fix bug", "refactor", "implement", "create PR", "open issue", "submit change".
+description: Ropy repository contribution workflow. Use for any code change that should become a commit — adding features, fixing bugs, refactoring, or any source modification. Drives the full Issue → Branch → PR → Merge process.
 ---
 
 # Ropy Contribution Flow
 
-The mandatory Issue → Branch → PR → Squash Merge workflow for any code change in this repo. General coding rules (TDD, `thiserror`, `gpui-component`, i18n, precheck) live in [`AGENTS.md`](../../../AGENTS.md) — this skill only covers the *process*.
-
-## Skip the Issue?
-
-Direct PR with no Issue is fine **only** for: typo / comment fixes, dependency bumps, pure `cargo fmt` output, CI tweaks. Everything else needs an Issue first.
+Issue → Branch → PR → Merge workflow for any code change in this repo. Coding standards live in [`AGENTS.md`](../../../AGENTS.md); this skill only covers the process.
 
 ## Conventional Commits
 
 - **Types**: `feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert`
 - **Scopes** (top-level modules): `gui | repository | clipboard | updater | i18n | config | gpui`
-- **Subject**: lowercase, imperative.
-- The Issue title, branch type, every commit, and the PR title must all agree.
+- **Subject**: lowercase, imperative mood, no trailing period.
+- **Consistency**: the `<type>` must match across the Issue title, branch prefix, every commit, and the PR title. The `<scope>` is required on commits and the PR title, optional on the Issue title, and omitted from the branch name.
 
 ## The flow
 
 ### 1. Open the Issue
 
-Templates: `feature_request.yml` (feature) · `bug_report.yml` (bug) · `refactor.yml` (internal cleanup).
+Pick a template from `.github/ISSUE_TEMPLATE/`. Fill it into `/tmp/ropy-issue.md`, then:
 
 ```bash
-cat > /tmp/ropy-issue.md <<'EOF'
-### Motivation
-<why this matters>
-
-### Proposed Solution
-<what will change>
-
-### Acceptance Criteria
-- [ ] <testable condition>
-
-### Scope
-gui   # or repository | clipboard | updater | i18n | config | gpui | other
-EOF
-
 gh issue create \
-  --title "feat: <short summary>" \
-  --label "enhancement" \
+  --title "<type>: ..."  \
+  --label "<from yml>" \
   --body-file /tmp/ropy-issue.md
 ```
 
 Capture the returned number as `<N>`.
 
+> **Skipping the Issue**: only when the user explicitly asks. Proceed to Step 2 with a descriptive branch name and note the skip in the PR description.
+
 ### 2. Branch from fresh `main`
 
 ```bash
 git checkout main && git pull --ff-only
-git checkout -b <type>/<N>-<kebab-slug>
-# e.g. feat/42-grid-layout, fix/57-clipboard-empty-x11
+git checkout -b <type>/<kebab-slug>
+# e.g. feat/grid-layout, fix/clipboard-empty-x11
 ```
 
 ### 3. Implement
 
-Follow `AGENTS.md`. Re-read it if you're unsure about TDD, error types, UI components, or i18n.
+Follow `AGENTS.md`. Re-read it if unsure about TDD, error types, UI components, or i18n.
 
-### 4. Precheck must pass before committing
+### 4. Precheck
+
+Must pass before any commit:
 
 ```bash
 ./scripts/precheck.sh
@@ -73,30 +59,16 @@ git commit -am "feat(gui): add grid layout mode
 Refs #<N>"
 ```
 
-Multiple commits are fine — they get squashed on merge.
+Multiple commits are fine — they are squashed on merge.
 
 ### 6. Push & open the PR
 
+Fill `.github/PULL_REQUEST_TEMPLATE.md` into `/tmp/ropy-pr.md`, then:
+
 ```bash
 git push -u origin HEAD
-
-cat > /tmp/ropy-pr.md <<EOF
-## Summary
-<one or two sentences>
-
-## Linked Issue
-Closes #<N>
-
-## Changes
-- <bullet>
-
-## Testing
-- [x] \`scripts/precheck.sh\` passes locally
-- [x] New / updated tests cover the change
-EOF
-
 gh pr create --base main \
-  --title "feat(gui): add grid layout mode" \
+  --title "<type>(<scope>): ..." \
   --body-file /tmp/ropy-pr.md
 ```
 
@@ -104,7 +76,7 @@ Report the PR URL back to the user.
 
 ### 7. Iterate on review
 
-Push more commits to the same branch. **No force-push after review starts** unless the user asks.
+Push additional commits to the same branch. **Do not force-push once a reviewer has left feedback**, unless the user explicitly requests it.
 
 ### 8. Merge — only on explicit user instruction
 
@@ -115,4 +87,4 @@ git checkout main && git pull --ff-only && git fetch --prune
 
 ## CI failures
 
-Required checks: `Precheck` and `Cross-platform build (macos-latest / windows-latest)`. Almost everything is reproducible via `./scripts/precheck.sh`. Inspect logs with `gh run view --log-failed`.
+Required checks: `Precheck` and `Cross-platform build (macos-latest / windows-latest)`. Most failures are reproducible locally via `./scripts/precheck.sh`. Inspect logs with `gh run view --log-failed`.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,8 +48,6 @@ body:
         - macOS
         - Windows
         - Linux (X11)
-        - Linux (Wayland)
-        - Other
     validations:
       required: true
   - type: textarea

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,6 @@
 - Follow all the best practices outlined in the clippy lint.
 - Define all error types with `thiserror` — avoid manual `impl Display/Error`.
 - Build new UI components using `gpui-component`.
-- Run `scripts/precheck.sh` before committing to verify code quality and formatting.
 - Localize all user-facing strings — no hardcoded display text in source files.
 - Follow the guidelines in [Testing](./docs/TESTING.md) for test structure, naming, and coverage expectations.
 


### PR DESCRIPTION
## Summary

Streamline the contribution flow skill documentation and clean up the issue template. The previous skill doc was overly verbose and contained redundancies with AGENTS.md.

## Linked Issue

N/A — skipped per explicit request.

## Changes

- Streamline `SKILL.md`: remove redundant verbosity, unify formatting, simplify templates
- Remove unused "Linux (Wayland)" and "Other" options from `bug_report.yml`
- Remove redundant precheck mention from `AGENTS.md` (already covered in the skill)

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] No code changes — documentation only

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings changed
- [x] No UI component changes
- [x] No unrelated changes mixed in
EOF; __aone_exit=$?; pwd -P > '/var/folders/k5/bgh7vydn1534l_665136wm040000gp/T/aone-copilot-cwd-1778162597388-t9slqmoyz7n.txt' 2>/dev/null; exit $__aone_exit