### PR TITLE
feat(gpui): always start hidden into tray

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@
 //! can focus solely on rendering.
 
 use std::{
-    cfg_select, env,
+    cfg_select,
     sync::{Arc, Mutex},
 };
 
@@ -252,15 +252,8 @@ fn load_settings() -> Settings {
     }
 }
 
-fn is_silent_launch(args: &[String]) -> bool {
-    args.iter().any(|arg| arg == crate::constants::SILENT_ARG)
-}
-
 /// Entry point: initialize all subsystems and launch the application.
 pub(crate) fn launch() {
-    let args: Vec<String> = env::args().collect();
-    let is_silent = is_silent_launch(&args);
-
     gpui::Application::new()
         .with_assets(crate::gui::Assets)
         .run(move |cx| {
@@ -289,8 +282,7 @@ pub(crate) fn launch() {
             let clipboard_rx = start_clipboard_monitor(cx, last_copy.clone());
             let copy_tx = clipboard::start_clipboard_writer(cx);
 
-            let window_handle =
-                crate::gui::create_window(cx, shared_records, last_copy, copy_tx, is_silent);
+            let window_handle = crate::gui::create_window(cx, shared_records, last_copy, copy_tx);
             start_clipboard_event_handler(clipboard_rx, window_handle, cx);
             let hotkey_tx =
                 setup_hotkey_listener(window_handle, settings.hotkey.activation_key.clone(), cx);
@@ -354,20 +346,6 @@ mod tests {
         .expect("Failed to create test repository");
 
         (temp_dir, repo)
-    }
-
-    #[test]
-    fn test_is_silent_launch_when_flag_is_present_returns_true() {
-        let args = vec!["ropy".to_string(), crate::constants::SILENT_ARG.to_string()];
-
-        assert!(is_silent_launch(&args));
-    }
-
-    #[test]
-    fn test_is_silent_launch_when_flag_is_missing_returns_false() {
-        let args = vec!["ropy".to_string(), "--verbose".to_string()];
-
-        assert!(!is_silent_launch(&args));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,7 +14,10 @@ use std::{
 use gpui::{App, AppContext, KeyBinding, ReadGlobal, WindowHandle};
 use gpui_component::Root;
 #[cfg(target_os = "linux")]
-use {crate::gui::x11::X11, std::sync::OnceLock};
+use {
+    crate::gui::x11::X11,
+    std::{env, sync::OnceLock},
+};
 
 use crate::{
     clipboard::{self, ClipboardEvent, LastCopyState},

--- a/src/config/autostart.rs
+++ b/src/config/autostart.rs
@@ -18,9 +18,9 @@ pub(crate) enum AutoStartError {
     StatusCheck(String),
 }
 
-/// Owns the platform `AutoLaunch` handle and threads the `--silent` flag
-/// through it so a system-triggered launch boots into the tray instead of
-/// popping the main window.
+/// Owns the platform `AutoLaunch` handle. The app always boots hidden into
+/// the tray, so no extra CLI flag is needed to differentiate a
+/// system-triggered launch from a user-triggered one.
 pub(crate) struct AutoStartManager {
     auto_launch: AutoLaunch,
 }
@@ -32,7 +32,6 @@ impl AutoStartManager {
         let auto_launch = AutoLaunchBuilder::new()
             .set_app_name(app_name)
             .set_app_path(&app_path)
-            .set_args(&[crate::constants::SILENT_ARG])
             .build()
             .map_err(|e| {
                 AutoStartError::Initialization(format!("Failed to build AutoLaunch: {e}"))

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,8 +5,4 @@
 /// "Ropy" in every locale.
 pub(crate) const APP_NAME: &str = "Ropy";
 
-/// Hidden CLI flag used by the auto-start launcher to suppress the
-/// initial window so the app boots silently into the tray.
-pub(crate) const SILENT_ARG: &str = "--silent";
-
 pub(crate) const BACK_ARROW: &str = "←";

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -42,12 +42,15 @@ impl AssetSource for Assets {
 }
 
 /// Create the main application window.
+///
+/// The window is always created hidden — Ropy is a tray-resident clipboard
+/// manager and is only revealed by the global hotkey or the tray menu,
+/// regardless of how the process was launched.
 pub(crate) fn create_window(
     cx: &mut App,
     shared_records: SharedRecords,
     last_copy: Arc<Mutex<LastCopyState>>,
     copy_tx: async_channel::Sender<crate::clipboard::CopyRequest>,
-    is_silent: bool,
 ) -> WindowHandle<Root> {
     let bounds = Bounds::centered(None, default_window_size(), cx);
     let window_opacity_percent = Settings::read(cx, |s| s.window.opacity_percent);
@@ -56,7 +59,7 @@ pub(crate) fn create_window(
             window_bounds: Some(WindowBounds::Windowed(bounds)),
             kind: WindowKind::PopUp,
             titlebar: None,
-            show: !is_silent, // When silent mode, do not show the window initially
+            show: false,
             window_background: background_appearance_for_opacity(window_opacity_percent),
             ..Default::default()
         },

--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -324,8 +324,16 @@ pub(crate) fn hide_window<T>(window: &mut Window, cx: &Context<'_, T>, pinned: b
 
 /// Restore the window and pull it to the foreground, mirroring the user's
 /// expectation that activating from the tray / hotkey gives focus.
-#[expect(unused_variables, clippy::needless_pass_by_ref_mut)]
+///
+/// `window.activate_window()` is called unconditionally so that a window
+/// created hidden (`WindowOptions::show = false`) is also brought on-screen
+/// the first time the user triggers the hotkey or the tray "Show" entry —
+/// on macOS this maps to `[NSWindow makeKeyAndOrderFront]`, which both
+/// orders the window front and gives it key status.
+#[expect(clippy::needless_pass_by_ref_mut)]
 pub(crate) fn active_window<T>(window: &mut Window, cx: &Context<'_, T>) {
+    window.activate_window();
+
     #[cfg(target_os = "windows")]
     if let Ok(window_handle) = HasWindowHandle::window_handle(window)
         && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()


### PR DESCRIPTION
## Summary

Drop the `--silent` CLI flag and the divergent startup path it enabled. Ropy now always boots hidden into the tray, regardless of how the process was launched, and the window is only revealed by the global hotkey or the tray menu.

## Linked Issue

Closes #99

## Changes

- Remove `SILENT_ARG` constant from `src/constants.rs`.
- Remove `is_silent_launch` helper and its two unit tests from `src/app.rs`; drop the now-unused `env` import.
- `gui::create_window` no longer takes an `is_silent` parameter; `WindowOptions::show` is hardcoded to `false`.
- `AutoStartManager` no longer injects `--silent` into the autostart entry; doc comment updated.

## Testing

- [x] `scripts/precheck.sh` passes locally (424 tests, no clippy warnings, i18n / icons / themes all OK)
- [x] Existing tests for the silent-flag behaviour are deleted along with the code they covered; no new tests needed since the surviving behaviour is "window starts hidden", which is exercised by every existing run of the app and by the unchanged hotkey / tray paths.

Manual verification to perform after merge:
- Launch normally → window stays hidden, tray icon present.
- Launch via autostart → window stays hidden, tray icon present.
- Press configured hotkey → window appears.
- Click tray menu "Show" → window appears.

## Self-Check

- [x] PR title follows Conventional Commits (`feat(gpui): ...`)
- [x] No hardcoded user-facing strings — i18n keys added to all locale files (N/A — no user-facing strings touched)
- [x] New UI components use `gpui-component` (N/A — no new components)
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`) (N/A — error types untouched)
- [x] No unrelated changes mixed in
