### PR TITLE
refactor(gpui): unify per-platform dispatch in window helpers

### DIFF
--- a/src/gui/utils.rs
+++ b/src/gui/utils.rs
@@ -296,20 +296,20 @@ pub(crate) fn hide_window<T>(window: &mut Window, cx: &Context<'_, T>, pinned: b
     if pinned {
         return;
     }
-    #[cfg(target_os = "windows")]
-    if let Ok(window_handle) = HasWindowHandle::window_handle(window)
-        && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
-    {
-        let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
-        // SAFETY: see module-level note. `SW_HIDE` only toggles visibility.
-        unsafe {
-            ShowWindow(hwnd, SW_HIDE);
-        }
-    }
-
     cfg_select! {
         target_os = "macos" => {
             cx.hide();
+        }
+        target_os = "windows" => {
+            if let Ok(window_handle) = HasWindowHandle::window_handle(window)
+                && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
+            {
+                let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
+                // SAFETY: see module-level note. `SW_HIDE` only toggles visibility.
+                unsafe {
+                    ShowWindow(hwnd, SW_HIDE);
+                }
+            }
         }
         target_os = "linux" => {
             if let Some(x11) = crate::app::X11_INSTANCE.get()
@@ -334,22 +334,22 @@ pub(crate) fn hide_window<T>(window: &mut Window, cx: &Context<'_, T>, pinned: b
 pub(crate) fn active_window<T>(window: &mut Window, cx: &Context<'_, T>) {
     window.activate_window();
 
-    #[cfg(target_os = "windows")]
-    if let Ok(window_handle) = HasWindowHandle::window_handle(window)
-        && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
-    {
-        let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
-        // SAFETY: see module-level note. Both calls only affect
-        // visibility / focus.
-        unsafe {
-            ShowWindow(hwnd, SW_RESTORE);
-            SetForegroundWindow(hwnd);
-        }
-    }
-
     cfg_select! {
         target_os = "macos" => {
             cx.activate(true);
+        }
+        target_os = "windows" => {
+            if let Ok(window_handle) = HasWindowHandle::window_handle(window)
+                && let RawWindowHandle::Win32(win32_handle) = window_handle.as_raw()
+            {
+                let hwnd = win32_handle.hwnd.get() as *mut std::ffi::c_void;
+                // SAFETY: see module-level note. Both calls only affect
+                // visibility / focus.
+                unsafe {
+                    ShowWindow(hwnd, SW_RESTORE);
+                    SetForegroundWindow(hwnd);
+                }
+            }
         }
         target_os = "linux" => {
             if let Some(x11) = crate::app::X11_INSTANCE.get()


### PR DESCRIPTION
## Summary

Pure cleanup inside `src/gui/utils.rs`. Both `hide_window` and `active_window` had two adjacent dispatch blocks: a standalone `#[cfg(target_os = "windows")]` block followed by a `cfg_select!` covering macOS / Linux / `_`. Fold the Windows path into each function's existing `cfg_select!` so every platform goes through the same dispatch site.

## Linked Issue

Closes #102

## Changes

- `hide_window`: move the Win32 `ShowWindow(hwnd, SW_HIDE)` block into the `cfg_select!` as a `target_os = "windows"` arm, alongside the existing macOS / Linux / `_` arms.
- `active_window`: same treatment for the Win32 `ShowWindow(hwnd, SW_RESTORE) + SetForegroundWindow(hwnd)` block.
- No platform logic added or removed. The X11 `map_window` ↔ `unmap_window` and Win32 `SW_RESTORE` ↔ `SW_HIDE` pairings (see #101) are preserved verbatim — they bridge the project's hide path with GPUI's activation path and must stay.

## Testing

- [x] `scripts/precheck.sh` passes locally — 424 tests, no clippy warnings, i18n / icons / themes all OK
- [x] New / updated tests cover the change — N/A, pure mechanical refactor; runtime semantics are unchanged because `cfg_select!` expands to the same compile-time branch selection as `#[cfg]`

## Self-Check

- [x] PR title follows Conventional Commits (`refactor(gpui): ...`)
- [x] No hardcoded user-facing strings — i18n keys added to all locale files (N/A)
- [x] New UI components use `gpui-component` (N/A)
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`) (N/A)
- [x] No unrelated changes mixed in
