### PR TITLE
refactor(gui): group board state flags into typed state objects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@
 - Build new UI components using `gpui-component`.
 - Localize all user-facing strings — no hardcoded display text in source files.
 - Follow the guidelines in [Testing](./docs/TESTING.md) for test structure, naming, and coverage expectations.
+- Log files can be viewed when troubleshooting problems.
 
 ## AI Collaboration Workflow
 

--- a/src/gui/board.rs
+++ b/src/gui/board.rs
@@ -74,8 +74,78 @@ pub(super) const fn search_query_should_reveal_selection(
     previous_query.is_empty() && !next_query.is_empty()
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct FilterState {
+    /// Active content type filter
+    pub(crate) content_filter: ContentFilter,
+    /// Whether to show only favorited records (independent of content type filter)
+    pub(crate) favorites_only: bool,
+    /// Active text search options
+    pub(crate) search_options: SearchOptions,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum GridRevealState {
+    #[default]
+    Auto,
+    Suppressed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum PreviewState {
+    #[default]
+    Hidden,
+    Visible,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum DeletionState {
+    #[default]
+    Idle,
+    Deleting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum ClearConfirmState {
+    #[default]
+    Hidden,
+    Visible,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct UiState {
+    pub(crate) grid_reveal: GridRevealState,
+    pub(crate) preview: PreviewState,
+    pub(crate) deletion: DeletionState,
+    pub(crate) clear_confirm: ClearConfirmState,
+}
+
+impl UiState {
+    pub(crate) const fn grid_auto_reveal_enabled(self) -> bool {
+        matches!(self.grid_reveal, GridRevealState::Auto)
+    }
+
+    pub(crate) const fn is_deleting_record(self) -> bool {
+        matches!(self.deletion, DeletionState::Deleting)
+    }
+
+    pub(crate) const fn clear_confirm_visible(self) -> bool {
+        matches!(self.clear_confirm, ClearConfirmState::Visible)
+    }
+
+    pub(crate) const fn preview_visible(self) -> bool {
+        matches!(self.preview, PreviewState::Visible)
+    }
+
+    pub(crate) const fn toggle_preview(&mut self) {
+        self.preview = match self.preview {
+            PreviewState::Hidden => PreviewState::Visible,
+            PreviewState::Visible => PreviewState::Hidden,
+        };
+    }
+}
+
 /// `RopyBoard` Main Window Component
-#[expect(clippy::struct_excessive_bools)]
 pub(crate) struct RopyBoard {
     pub(crate) records: SharedRecords,
     pub(crate) filtered_record_indices: Arc<Vec<usize>>, // The final shown record indices
@@ -87,30 +157,20 @@ pub(crate) struct RopyBoard {
     pub(crate) last_search_query: String,
     pub(crate) list_state: ListState,
     pub(crate) grid_scroll_handle: ScrollHandle,
-    pub(crate) grid_auto_reveal_suppressed: bool,
+    pub(crate) ui_state: UiState,
     pub(crate) selected_index: usize,
     pub(crate) copy_tx: async_channel::Sender<crate::clipboard::CopyRequest>,
     pub(crate) last_copy: Arc<Mutex<LastCopyState>>,
     pub(crate) active_panel: ActivePanel,
-    pub(crate) show_preview: bool,
     pub(crate) settings_editor: SettingsEditor,
     pub(crate) confirm_mode: ConfirmMode,
     pub(crate) layout_mode: LayoutMode,
     pub(crate) pinned: bool,
     pub(crate) hotkey_tx: Option<async_channel::Sender<String>>,
-    /// Track if we're in a delete operation to preserve scroll position
-    pub(crate) deleting_record: bool,
     pub(crate) update_manager: UpdateManager,
-    /// Whether the clear-all confirmation dialog is visible
-    pub(crate) show_clear_confirm: bool,
     /// Which clear action is currently awaiting confirmation
     clear_confirm_action: ClearConfirmAction,
-    /// Active content type filter
-    pub(crate) content_filter: ContentFilter,
-    /// Whether to show only favorited records (independent of content type filter)
-    pub(crate) favorites_only: bool,
-    /// Active text search options
-    pub(crate) search_options: SearchOptions,
+    pub(crate) filter_state: FilterState,
 }
 
 impl RopyBoard {
@@ -152,7 +212,7 @@ impl RopyBoard {
                 .list_state
                 .scroll_to_reveal_item(self.selected_list_index()),
             LayoutMode::Grid => {
-                if !self.grid_auto_reveal_suppressed {
+                if self.ui_state.grid_auto_reveal_enabled() {
                     self.grid_scroll_handle.scroll_to_item(self.selected_index);
                 }
             }
@@ -160,20 +220,22 @@ impl RopyBoard {
     }
 
     pub(crate) fn force_reveal_selected_record(&mut self) {
-        self.grid_auto_reveal_suppressed = false;
+        self.ui_state.grid_reveal = GridRevealState::Auto;
         self.reveal_selected_record();
     }
 
     pub(crate) fn suppress_grid_auto_reveal(&mut self) {
         if self.layout_mode == LayoutMode::Grid {
-            self.grid_auto_reveal_suppressed = true;
+            self.ui_state.grid_reveal = GridRevealState::Suppressed;
         }
     }
 
     #[expect(clippy::needless_pass_by_ref_mut)]
     pub(crate) fn open_settings_panel(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) {
         self.active_panel = ActivePanel::Settings;
-        self.settings_editor.settings_window_opacity_slider_visible = false;
+        self.settings_editor
+            .panel_state
+            .window_opacity_slider_visible = false;
         window.focus(&self.focus_handle);
 
         let weak_entity = cx.entity().downgrade();
@@ -183,7 +245,10 @@ impl RopyBoard {
                     return;
                 }
 
-                board.settings_editor.settings_window_opacity_slider_visible = true;
+                board
+                    .settings_editor
+                    .panel_state
+                    .window_opacity_slider_visible = true;
                 window.focus(&board.focus_handle);
                 cx.notify();
             });
@@ -384,7 +449,7 @@ impl RopyBoard {
             search_input,
             last_search_query: String::new(),
             grid_scroll_handle: ScrollHandle::new(),
-            grid_auto_reveal_suppressed: false,
+            ui_state: UiState::default(),
             selected_index: 0,
             last_copy,
             list_state,
@@ -392,19 +457,14 @@ impl RopyBoard {
             favorite_ids,
             copy_tx,
             active_panel: ActivePanel::default(),
-            show_preview: false,
             settings_editor,
             confirm_mode,
             layout_mode,
             pinned: false,
             hotkey_tx: None,
-            deleting_record: false,
             update_manager: UpdateManager::new(),
-            show_clear_confirm: false,
             clear_confirm_action: ClearConfirmAction::AllHistory,
-            content_filter: ContentFilter::default(),
-            favorites_only: false,
-            search_options: SearchOptions::default(),
+            filter_state: FilterState::default(),
         }
     }
 }

--- a/src/gui/board/actions.rs
+++ b/src/gui/board/actions.rs
@@ -246,7 +246,7 @@ impl RopyBoard {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        if self.active_panel == ActivePanel::Settings && self.settings_editor.hotkey_recording {
+        if self.active_panel == ActivePanel::Settings && self.settings_editor.hotkey.recording {
             return;
         }
 
@@ -256,7 +256,7 @@ impl RopyBoard {
         }
         self.force_reveal_selected_record();
         self.active_panel = ActivePanel::ClipboardList;
-        self.show_clear_confirm = false;
+        self.ui_state.clear_confirm = crate::gui::board::ClearConfirmState::Hidden;
         reset_window_geometry_for_activation(window, default_window_size());
         active_window(window, cx);
     }
@@ -267,13 +267,13 @@ impl RopyBoard {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        if self.active_panel == ActivePanel::Settings && self.settings_editor.hotkey_recording {
+        if self.active_panel == ActivePanel::Settings && self.settings_editor.hotkey.recording {
             self.cancel_hotkey_recording(window, cx);
             return;
         }
 
-        if self.show_clear_confirm {
-            self.show_clear_confirm = false;
+        if self.ui_state.clear_confirm_visible() {
+            self.ui_state.clear_confirm = crate::gui::board::ClearConfirmState::Hidden;
             cx.notify();
             return;
         }
@@ -330,8 +330,7 @@ impl RopyBoard {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        // Block keyboard shortcuts while the clear-confirm dialog is open
-        if self.show_clear_confirm {
+        if self.ui_state.clear_confirm_visible() {
             return;
         }
 
@@ -347,7 +346,7 @@ impl RopyBoard {
                 window.focus(&self.search_input.focus_handle(cx));
             }
             "space" => {
-                self.show_preview = !self.show_preview;
+                self.ui_state.toggle_preview();
                 cx.notify();
             }
             "p" if self.can_toggle_window_pin() => {

--- a/src/gui/board/clear_confirm.rs
+++ b/src/gui/board/clear_confirm.rs
@@ -40,7 +40,7 @@ pub(super) fn render_clear_confirm_overlay(
         .justify_center()
         .id("clear-confirm-backdrop")
         .on_click(cx.listener(|this, _, _, cx| {
-            this.show_clear_confirm = false;
+            this.ui_state.clear_confirm = crate::gui::board::ClearConfirmState::Hidden;
             cx.notify();
         }))
         .child(
@@ -77,7 +77,8 @@ pub(super) fn render_clear_confirm_overlay(
                                 .ghost()
                                 .label(cancel_label)
                                 .on_click(cx.listener(|this, _, _, cx| {
-                                    this.show_clear_confirm = false;
+                                    this.ui_state.clear_confirm =
+                                        crate::gui::board::ClearConfirmState::Hidden;
                                     cx.notify();
                                 })),
                         )
@@ -88,7 +89,8 @@ pub(super) fn render_clear_confirm_overlay(
                                 .label(confirm_label)
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     this.confirm_clear_action(cx);
-                                    this.show_clear_confirm = false;
+                                    this.ui_state.clear_confirm =
+                                        crate::gui::board::ClearConfirmState::Hidden;
                                     cx.notify();
                                 })),
                         ),

--- a/src/gui/board/hotkey_record_handler.rs
+++ b/src/gui/board/hotkey_record_handler.rs
@@ -145,7 +145,7 @@ impl RopyBoard {
         cx: &mut Context<'_, Self>,
     ) {
         self.settings_editor.hotkey_before_recording = self.resolve_activation_key_input(cx);
-        self.settings_editor.hotkey_recording = true;
+        self.settings_editor.hotkey.recording = true;
         self.refresh_activation_key_placeholder(window, cx);
         self.settings_editor
             .settings_activation_key_input
@@ -161,7 +161,7 @@ impl RopyBoard {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        self.settings_editor.hotkey_recording = false;
+        self.settings_editor.hotkey.recording = false;
         self.settings_editor.pending_hotkey.clear();
         self.sync_activation_key_input_from_candidate("", window, cx);
         window.focus(
@@ -178,7 +178,7 @@ impl RopyBoard {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        self.settings_editor.hotkey_recording = false;
+        self.settings_editor.hotkey.recording = false;
         self.settings_editor
             .pending_hotkey
             .clone_from(&self.settings_editor.hotkey_before_recording);
@@ -199,7 +199,7 @@ impl RopyBoard {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
-        if !self.settings_editor.hotkey_recording {
+        if !self.settings_editor.hotkey.recording {
             return;
         }
 
@@ -217,7 +217,7 @@ impl RopyBoard {
             return;
         };
 
-        self.settings_editor.hotkey_recording = false;
+        self.settings_editor.hotkey.recording = false;
         self.settings_editor.pending_hotkey.clone_from(&hotkey);
         self.sync_activation_key_input(
             &hotkey,

--- a/src/gui/board/record_ops.rs
+++ b/src/gui/board/record_ops.rs
@@ -34,7 +34,7 @@ impl RopyBoard {
             self.filtered_record_indices.as_ref(),
             next_indices,
             self.selected_index,
-            self.deleting_record,
+            self.ui_state.is_deleting_record(),
         );
         let next_visible_len = self.visible_list_len(plan.indices.len());
 
@@ -59,7 +59,7 @@ impl RopyBoard {
         }
 
         if plan.clear_deleting_record {
-            self.deleting_record = false;
+            self.ui_state.deletion = crate::gui::board::DeletionState::Idle;
         }
 
         if reveal_selection {
@@ -145,7 +145,7 @@ impl RopyBoard {
         cx: &mut Context<'_, Self>,
     ) {
         self.clear_confirm_action = action;
-        self.show_clear_confirm = true;
+        self.ui_state.clear_confirm = crate::gui::board::ClearConfirmState::Visible;
         cx.notify();
     }
 
@@ -171,7 +171,7 @@ impl RopyBoard {
                 if let Err(e) = repo.delete(id) {
                     tracing::warn!(error = %e, "failed to delete clipboard record");
                 } else {
-                    self.deleting_record = true;
+                    self.ui_state.deletion = crate::gui::board::DeletionState::Deleting;
                     self.refresh_records_from_repository(cx);
                 }
             }
@@ -210,25 +210,26 @@ impl RopyBoard {
     /// Click-to-toggle behavior: re-clicking the active filter clears it
     /// (back to `All`) so the same button serves as both apply and reset.
     pub(crate) fn toggle_content_filter(&mut self, target: ContentFilter) {
-        if self.content_filter == target {
-            self.content_filter = ContentFilter::All;
+        if self.filter_state.content_filter == target {
+            self.filter_state.content_filter = ContentFilter::All;
         } else {
-            self.content_filter = target;
+            self.filter_state.content_filter = target;
         }
     }
 
     /// Favorites toggle is intentionally orthogonal to the content filter
     /// so users can scope to e.g. "favorited images only".
     pub(crate) const fn toggle_favorites_only(&mut self) {
-        self.favorites_only = !self.favorites_only;
+        self.filter_state.favorites_only = !self.filter_state.favorites_only;
     }
 
     pub(crate) const fn toggle_case_sensitive_search(&mut self) {
-        self.search_options.case_sensitive = !self.search_options.case_sensitive;
+        self.filter_state.search_options.case_sensitive =
+            !self.filter_state.search_options.case_sensitive;
     }
 
     pub(crate) const fn toggle_whole_word_search(&mut self) {
-        self.search_options.whole_word = !self.search_options.whole_word;
+        self.filter_state.search_options.whole_word = !self.filter_state.search_options.whole_word;
     }
 
     pub(super) fn get_filtered_record_indices(&self, query: &str) -> Vec<usize> {
@@ -236,10 +237,10 @@ impl RopyBoard {
         filter_and_sort_record_indices(
             &records,
             query,
-            self.content_filter,
-            self.search_options,
+            self.filter_state.content_filter,
+            self.filter_state.search_options,
             &self.favorite_ids,
-            self.favorites_only,
+            self.filter_state.favorites_only,
         )
     }
 

--- a/src/gui/board/records_list/row.rs
+++ b/src/gui/board/records_list/row.rs
@@ -266,15 +266,61 @@ impl ItemStyle {
     }
 }
 
-#[expect(clippy::struct_excessive_bools)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FavoriteState {
+    Favorite,
+    NotFavorite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SelectionState {
+    Selected,
+    Unselected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PreviewVisibility {
+    Visible,
+    Hidden,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum HoverPreviewState {
+    Enabled,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RenderFlags {
+    favorite: FavoriteState,
+    selection: SelectionState,
+    preview: PreviewVisibility,
+    hover_preview: HoverPreviewState,
+}
+
+impl RenderFlags {
+    const fn is_favorite(self) -> bool {
+        matches!(self.favorite, FavoriteState::Favorite)
+    }
+
+    const fn is_selected(self) -> bool {
+        matches!(self.selection, SelectionState::Selected)
+    }
+
+    const fn preview_visible(self) -> bool {
+        matches!(self.preview, PreviewVisibility::Visible)
+    }
+
+    const fn hover_preview_enabled(self) -> bool {
+        matches!(self.hover_preview, HoverPreviewState::Enabled)
+    }
+}
+
 pub(super) struct RenderContext<'a> {
     index: usize,
     record: &'a ClipboardRecord,
-    is_favorite: bool,
-    is_selected: bool,
+    flags: RenderFlags,
     layout_mode: LayoutMode,
-    show_preview: bool,
-    hover_preview_enabled: bool,
     opacity_percent: u8,
     view: &'a gpui::WeakEntity<RopyBoard>,
 }
@@ -299,9 +345,9 @@ impl RecordsListState {
             favorite_ids: board.favorite_ids.clone(),
             selected_index: board.selected_index,
             layout_mode: board.layout_mode,
-            show_preview: board.show_preview,
-            hover_preview_enabled: board.settings_editor.hover_preview_enabled
-                && !board.show_clear_confirm,
+            show_preview: board.ui_state.preview_visible(),
+            hover_preview_enabled: board.settings_editor.panel_state.hover_preview_enabled
+                && !board.ui_state.clear_confirm_visible(),
             opacity_percent: board.settings_editor.window_opacity_percent,
             view: context.weak_entity(),
         }
@@ -333,11 +379,29 @@ impl RecordsListState {
         RenderContext {
             index,
             record,
-            is_favorite: self.favorite_ids.contains(&record.id),
-            is_selected: index == self.selected_index,
+            flags: RenderFlags {
+                favorite: if self.favorite_ids.contains(&record.id) {
+                    FavoriteState::Favorite
+                } else {
+                    FavoriteState::NotFavorite
+                },
+                selection: if index == self.selected_index {
+                    SelectionState::Selected
+                } else {
+                    SelectionState::Unselected
+                },
+                preview: if self.show_preview {
+                    PreviewVisibility::Visible
+                } else {
+                    PreviewVisibility::Hidden
+                },
+                hover_preview: if self.hover_preview_enabled {
+                    HoverPreviewState::Enabled
+                } else {
+                    HoverPreviewState::Disabled
+                },
+            },
             layout_mode: self.layout_mode,
-            show_preview: self.show_preview,
-            hover_preview_enabled: self.hover_preview_enabled,
             opacity_percent: self.opacity_percent,
             view: &self.view,
         }
@@ -353,7 +417,7 @@ fn render_record_body(
     let compact = ctx.layout_mode == LayoutMode::Grid;
     let mut content = div().flex_1().min_w_0().id(("record-content", ctx.index));
 
-    if !ctx.show_preview && ctx.hover_preview_enabled {
+    if !ctx.flags.preview_visible() && ctx.flags.hover_preview_enabled() {
         let preview_content_type = preview_data.content_type.clone();
         let preview_record_content = preview_data.record_content.clone();
         content = content.tooltip(move |window, cx| {
@@ -457,7 +521,7 @@ fn render_record_actions(ctx: &RenderContext<'_>) -> AnyElement {
     let view_delete = ctx.view.clone();
 
     let favorite_button = {
-        let button = if ctx.is_favorite {
+        let button = if ctx.flags.is_favorite() {
             Button::new(("favorite-btn", index))
                 .xsmall()
                 .primary()
@@ -562,14 +626,14 @@ fn decorate_record_card(
 
     card.bg(styles.normal_background)
         .rounded_md()
-        .border_color(if ctx.is_selected {
+        .border_color(if ctx.flags.is_selected() {
             styles.hover_border
         } else {
             styles.border
         })
         .border_1()
         .hover(move |style| {
-            if ctx.is_selected {
+            if ctx.flags.is_selected() {
                 style
             } else {
                 style
@@ -651,7 +715,7 @@ pub(super) fn render_list_item_with_grid_height(
         div().pb_2().relative().child(card)
     };
 
-    if ctx.hover_preview_enabled && ctx.is_selected && ctx.show_preview {
+    if ctx.flags.hover_preview_enabled() && ctx.flags.is_selected() && ctx.flags.preview_visible() {
         item = item.child(render_selected_preview(&preview_data, window, cx));
     }
 

--- a/src/gui/board/render.rs
+++ b/src/gui/board/render.rs
@@ -56,7 +56,7 @@ impl Render for RopyBoard {
         // Render each notification directly in a bottom-right column.
         let notifs: Vec<_> = window.notifications(cx).iter().cloned().collect();
         let has_notifs = !notifs.is_empty();
-        let show_clear_confirm = self.show_clear_confirm;
+        let show_clear_confirm = self.ui_state.clear_confirm_visible();
         let clear_confirm_action = self.clear_confirm_action;
         gpui::div()
             .relative()

--- a/src/gui/board/search.rs
+++ b/src/gui/board/search.rs
@@ -187,7 +187,7 @@ fn create_case_sensitive_button(board: &RopyBoard, cx: &Context<'_, RopyBoard>) 
         board.settings_editor.window_opacity_percent,
         "search-case-sensitive-btn",
         "Aa",
-        board.search_options.case_sensitive,
+        board.filter_state.search_options.case_sensitive,
         I18n::translate(cx, "search_case_sensitive"),
         cx,
     )
@@ -204,7 +204,7 @@ fn create_whole_word_button(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> B
         board.settings_editor.window_opacity_percent,
         "search-whole-word-btn",
         "W",
-        board.search_options.whole_word,
+        board.filter_state.search_options.whole_word,
         I18n::translate(cx, "search_match_whole_word"),
         cx,
     )
@@ -273,19 +273,19 @@ fn render_filter_buttons(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl
     let files_filter_tooltip = I18n::translate(cx, "filter_files");
     let opacity_percent = board.settings_editor.window_opacity_percent;
 
-    let text_button = if board.content_filter == ContentFilter::Text {
+    let text_button = if board.filter_state.content_filter == ContentFilter::Text {
         Button::new("filter-text-btn").primary()
     } else {
         Button::new("filter-text-btn").ghost()
     };
 
-    let image_button = if board.content_filter == ContentFilter::Image {
+    let image_button = if board.filter_state.content_filter == ContentFilter::Image {
         Button::new("filter-image-btn").primary()
     } else {
         Button::new("filter-image-btn").ghost()
     };
 
-    let files_button = if board.content_filter == ContentFilter::Files {
+    let files_button = if board.filter_state.content_filter == ContentFilter::Files {
         Button::new("filter-files-btn").primary()
     } else {
         Button::new("filter-files-btn").ghost()
@@ -342,7 +342,7 @@ fn render_favorites_button(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> im
     let favorites_filter_tooltip = I18n::translate(cx, "filter_favorites");
     let opacity_percent = board.settings_editor.window_opacity_percent;
 
-    let favorites_button = if board.favorites_only {
+    let favorites_button = if board.filter_state.favorites_only {
         Button::new("filter-favorites-btn").primary()
     } else {
         Button::new("filter-favorites-btn").ghost()

--- a/src/gui/board/settings_editor.rs
+++ b/src/gui/board/settings_editor.rs
@@ -9,34 +9,56 @@ use gpui_component::{
 use super::RopyBoard;
 use crate::{config::LayoutMode, gui::theme::ThemeId, i18n::Language};
 
+#[derive(Debug, Clone, Copy, Default)]
 #[expect(clippy::redundant_pub_crate)]
-#[expect(clippy::struct_excessive_bools)]
+pub(crate) struct HotkeyEditorState {
+    pub(crate) recording: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[expect(clippy::redundant_pub_crate)]
+pub(crate) struct SettingsPanelState {
+    pub(crate) window_opacity_slider_visible: bool,
+    pub(crate) hover_preview_enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[expect(clippy::redundant_pub_crate)]
+pub(crate) struct AutostartSettingsState {
+    pub(crate) enabled: bool,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+#[expect(clippy::redundant_pub_crate)]
+pub(crate) struct UpdateSettingsState {
+    pub(crate) auto_check_enabled: bool,
+    pub(crate) include_prerelease_enabled: bool,
+}
+
+#[expect(clippy::redundant_pub_crate)]
 pub(crate) struct SettingsEditor {
-    pub(crate) hotkey_recording: bool,
+    pub(crate) hotkey: HotkeyEditorState,
     pub(crate) pending_hotkey: String,
     pub(crate) hotkey_before_recording: String,
     pub(crate) settings_activation_key_input: Entity<InputState>,
     pub(crate) settings_max_history_input: Entity<InputState>,
     pub(crate) settings_max_storage_input: Entity<InputState>,
     pub(crate) settings_window_opacity_slider: Entity<SliderState>,
-    pub(crate) settings_window_opacity_slider_visible: bool,
+    pub(crate) panel_state: SettingsPanelState,
     pub(crate) selected_theme: usize,
     pub(crate) theme_select: Entity<SelectState<Vec<SharedString>>>,
     pub(crate) selected_layout: usize,
     pub(crate) layout_select: Entity<SelectState<Vec<SharedString>>>,
     pub(crate) window_opacity_percent: u8,
-    pub(crate) autostart_enabled: bool,
+    pub(crate) autostart: AutostartSettingsState,
     pub(crate) selected_language: usize,
     pub(crate) language_select: Entity<SelectState<Vec<SharedString>>>,
-    pub(crate) auto_check_enabled: bool,
-    pub(crate) include_prerelease_enabled: bool,
-    pub(crate) hover_preview_enabled: bool,
+    pub(crate) update_settings: UpdateSettingsState,
 }
 
 impl SettingsEditor {
     #[expect(clippy::too_many_arguments)]
     #[expect(clippy::fn_params_excessive_bools)]
-    #[expect(clippy::missing_const_for_fn)]
     pub(super) fn new(
         pending_hotkey: String,
         hotkey_before_recording: String,
@@ -57,25 +79,31 @@ impl SettingsEditor {
         hover_preview_enabled: bool,
     ) -> Self {
         Self {
-            hotkey_recording: false,
+            hotkey: HotkeyEditorState::default(),
             pending_hotkey,
             hotkey_before_recording,
             settings_activation_key_input,
             settings_max_history_input,
             settings_max_storage_input,
             settings_window_opacity_slider,
-            settings_window_opacity_slider_visible: false,
+            panel_state: SettingsPanelState {
+                window_opacity_slider_visible: false,
+                hover_preview_enabled,
+            },
             selected_theme,
             theme_select,
             selected_layout,
             layout_select,
             window_opacity_percent,
-            autostart_enabled,
+            autostart: AutostartSettingsState {
+                enabled: autostart_enabled,
+            },
             selected_language,
             language_select,
-            auto_check_enabled,
-            include_prerelease_enabled,
-            hover_preview_enabled,
+            update_settings: UpdateSettingsState {
+                auto_check_enabled,
+                include_prerelease_enabled,
+            },
         }
     }
 }

--- a/src/gui/board/settings_handler.rs
+++ b/src/gui/board/settings_handler.rs
@@ -139,7 +139,7 @@ impl RopyBoard {
 
     pub(crate) fn toggle_autostart(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) {
         let previous_value = Settings::read(cx, |s| s.autostart.enabled);
-        let next_value = !self.settings_editor.autostart_enabled;
+        let next_value = !self.settings_editor.autostart.enabled;
 
         if let Err(error_message) = Self::persist_settings_update(cx, |settings| {
             settings.autostart.enabled = next_value;
@@ -155,7 +155,7 @@ impl RopyBoard {
             }) {
                 Self::notify_settings_save_failed(window, cx, &rollback_error);
             }
-            self.settings_editor.autostart_enabled = Settings::read(cx, |s| s.autostart.enabled);
+            self.settings_editor.autostart.enabled = Settings::read(cx, |s| s.autostart.enabled);
             Self::notify_settings_warning(
                 window,
                 cx,
@@ -165,7 +165,7 @@ impl RopyBoard {
             return;
         }
 
-        self.settings_editor.autostart_enabled = next_value;
+        self.settings_editor.autostart.enabled = next_value;
         Self::notify_settings_success(window, cx, I18n::translate(cx, "settings_save_success"));
         cx.notify();
     }
@@ -211,7 +211,7 @@ impl RopyBoard {
             return;
         }
 
-        self.settings_editor.hover_preview_enabled = enabled;
+        self.settings_editor.panel_state.hover_preview_enabled = enabled;
         Self::notify_settings_success(window, cx, I18n::translate(cx, "settings_save_success"));
         cx.notify();
     }

--- a/src/gui/board/settings_handler/hotkey.rs
+++ b/src/gui/board/settings_handler/hotkey.rs
@@ -144,7 +144,7 @@ impl RopyBoard {
         }
 
         if activation_key == current_hotkey {
-            self.settings_editor.hotkey_recording = false;
+            self.settings_editor.hotkey.recording = false;
             self.settings_editor
                 .pending_hotkey
                 .clone_from(&activation_key);
@@ -164,7 +164,7 @@ impl RopyBoard {
             return;
         }
 
-        self.settings_editor.hotkey_recording = false;
+        self.settings_editor.hotkey.recording = false;
         self.settings_editor
             .pending_hotkey
             .clone_from(&activation_key);

--- a/src/gui/board/settings_handler/update.rs
+++ b/src/gui/board/settings_handler/update.rs
@@ -24,7 +24,7 @@ impl RopyBoard {
             return;
         }
 
-        self.settings_editor.auto_check_enabled = enabled;
+        self.settings_editor.update_settings.auto_check_enabled = enabled;
         Self::notify_settings_success(window, cx, I18n::translate(cx, "settings_save_success"));
         cx.notify();
     }
@@ -47,7 +47,9 @@ impl RopyBoard {
             return;
         }
 
-        self.settings_editor.include_prerelease_enabled = enabled;
+        self.settings_editor
+            .update_settings
+            .include_prerelease_enabled = enabled;
         Self::notify_settings_success(window, cx, I18n::translate(cx, "settings_save_success"));
         cx.notify();
     }

--- a/src/gui/panel/settings.rs
+++ b/src/gui/panel/settings.rs
@@ -215,7 +215,11 @@ fn render_window_opacity_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> 
                     .bg(cx.theme().accent)
                     .text_color(cx.theme().accent_foreground)
                     .opacity(
-                        if board.settings_editor.settings_window_opacity_slider_visible {
+                        if board
+                            .settings_editor
+                            .panel_state
+                            .window_opacity_slider_visible
+                        {
                             1.0_f32
                         } else {
                             0.0_f32
@@ -249,19 +253,19 @@ fn render_window_opacity_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> 
 fn render_hotkey_controls(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl IntoElement {
     let is_dirty = board.has_pending_hotkey(cx);
 
-    let border_color = if board.settings_editor.hotkey_recording {
+    let border_color = if board.settings_editor.hotkey.recording {
         cx.theme().accent
     } else {
         cx.theme().border
     };
 
-    let record_tooltip = if board.settings_editor.hotkey_recording {
+    let record_tooltip = if board.settings_editor.hotkey.recording {
         I18n::translate(cx, "settings_hotkey_record_hint")
     } else {
         I18n::translate(cx, "settings_hotkey_record")
     };
 
-    let record_button = if board.settings_editor.hotkey_recording {
+    let record_button = if board.settings_editor.hotkey.recording {
         Button::new("hotkey-record-button").primary()
     } else {
         Button::new("hotkey-record-button")
@@ -299,7 +303,7 @@ fn render_hotkey_controls(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> imp
                 .icon(Icon::empty().path("icons/hotkey-record.svg").size(px(14.0)))
                 .tooltip(record_tooltip)
                 .on_click(cx.listener(|board, _, window, cx| {
-                    if board.settings_editor.hotkey_recording {
+                    if board.settings_editor.hotkey.recording {
                         board.cancel_hotkey_recording(window, cx);
                     } else {
                         board.start_hotkey_recording(window, cx);
@@ -408,7 +412,7 @@ fn render_max_storage_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> imp
 
 fn render_autostart_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl IntoElement {
     let toggle = Switch::new("autostart-toggle")
-        .checked(board.settings_editor.autostart_enabled)
+        .checked(board.settings_editor.autostart.enabled)
         .on_click(cx.listener(|board, _, window, cx| {
             board.toggle_autostart(window, cx);
         }));
@@ -441,10 +445,10 @@ fn render_confirm_mode_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> im
 
 fn render_hover_preview_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl IntoElement {
     let toggle = Switch::new("hover-preview-toggle")
-        .checked(board.settings_editor.hover_preview_enabled)
+        .checked(board.settings_editor.panel_state.hover_preview_enabled)
         .on_click(cx.listener(|board, _, window, cx| {
             board.save_hover_preview_enabled(
-                !board.settings_editor.hover_preview_enabled,
+                !board.settings_editor.panel_state.hover_preview_enabled,
                 window,
                 cx,
             );
@@ -518,9 +522,13 @@ fn render_open_dirs_row(cx: &Context<'_, RopyBoard>) -> impl IntoElement {
 
 fn render_auto_check_row(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl IntoElement {
     let toggle = Switch::new("auto-check-toggle")
-        .checked(board.settings_editor.auto_check_enabled)
+        .checked(board.settings_editor.update_settings.auto_check_enabled)
         .on_click(cx.listener(|board, _, window, cx| {
-            board.save_auto_check_enabled(!board.settings_editor.auto_check_enabled, window, cx);
+            board.save_auto_check_enabled(
+                !board.settings_editor.update_settings.auto_check_enabled,
+                window,
+                cx,
+            );
         }));
     settings_row(I18n::translate(cx, "update_auto_check"), toggle, cx)
 }
@@ -530,10 +538,18 @@ fn render_include_prerelease_row(
     cx: &Context<'_, RopyBoard>,
 ) -> impl IntoElement {
     let toggle = Switch::new("include-prerelease-toggle")
-        .checked(board.settings_editor.include_prerelease_enabled)
+        .checked(
+            board
+                .settings_editor
+                .update_settings
+                .include_prerelease_enabled,
+        )
         .on_click(cx.listener(|board, _, window, cx| {
             board.save_include_prerelease_enabled(
-                !board.settings_editor.include_prerelease_enabled,
+                !board
+                    .settings_editor
+                    .update_settings
+                    .include_prerelease_enabled,
                 window,
                 cx,
             );
@@ -589,10 +605,13 @@ pub(crate) fn reset_settings_dialog(
     board.settings_editor.selected_language = lang_idx;
     board.settings_editor.selected_theme = theme_idx;
     board.settings_editor.selected_layout = layout_idx;
-    board.settings_editor.autostart_enabled = autostart_enabled;
-    board.settings_editor.auto_check_enabled = auto_check_enabled;
-    board.settings_editor.include_prerelease_enabled = include_prerelease_enabled;
-    board.settings_editor.hover_preview_enabled = hover_preview_enabled;
+    board.settings_editor.autostart.enabled = autostart_enabled;
+    board.settings_editor.update_settings.auto_check_enabled = auto_check_enabled;
+    board
+        .settings_editor
+        .update_settings
+        .include_prerelease_enabled = include_prerelease_enabled;
+    board.settings_editor.panel_state.hover_preview_enabled = hover_preview_enabled;
     board.confirm_mode = confirm_mode;
     board.layout_mode = layout_mode;
     board.settings_editor.window_opacity_percent = window_opacity;
@@ -601,7 +620,7 @@ pub(crate) fn reset_settings_dialog(
         .pending_hotkey
         .clone_from(&activation_key);
     board.settings_editor.hotkey_before_recording = activation_key;
-    board.settings_editor.hotkey_recording = false;
+    board.settings_editor.hotkey.recording = false;
 
     // Reset the language select dropdown
     board
@@ -628,7 +647,10 @@ pub(crate) fn reset_settings_dialog(
         .update(cx, |input, cx| {
             input.set_value("", window, cx);
         });
-    board.settings_editor.settings_window_opacity_slider_visible = false;
+    board
+        .settings_editor
+        .panel_state
+        .window_opacity_slider_visible = false;
     board.sync_window_opacity_slider(window_opacity, window, cx);
     let theme = ThemeId::all().get(theme_idx).cloned().unwrap_or_default();
     crate::gui::app::set_app_theme(window, cx, &theme, window_opacity);


### PR DESCRIPTION
## Summary

Refactor board and settings state into grouped state objects so the board logic reads in terms of domain state instead of scattered top-level flags.

## Linked Issue

Closes #107

## Changes

- group board UI and search-related flags into `UiState` and `FilterState`
- group settings editor booleans into nested state structs and update dependent call sites
- replace row render booleans with typed render flags for clearer conditional rendering

## Testing

- [x] `scripts/precheck.sh` passes locally
- [ ] New / updated tests cover the change
- `cargo test --quiet board`

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files
- [x] New UI components use `gpui-component`
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`)
- [x] No unrelated changes mixed in
