### PR TITLE
refactor(updater): remove hex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5659,7 +5659,6 @@ dependencies = [
  "gpui",
  "gpui-component",
  "gtk",
- "hex",
  "image",
  "objc2",
  "postcard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ seahash = "4.1.0"
 sha2 = "0.11.0"
 self-replace = "1.5.0"
 semver = "1.0.28"
-hex = "0.4.3"
 tempfile = "3.27.0"
 enigo = "0.6.1"
 
@@ -52,6 +51,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
     "std",
     "time",
 ] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6.4"
 

--- a/src/updater/downloader.rs
+++ b/src/updater/downloader.rs
@@ -9,6 +9,8 @@ use sha2::{Digest, Sha256};
 
 use super::{errors::UpdateError, models::ReleaseInfo};
 
+const HEX_CHARS: &[u8; 16] = b"0123456789abcdef";
+
 /// Download the release asset, verify its checksum, extract the binary, and
 /// replace the running executable.
 ///
@@ -170,7 +172,15 @@ fn compute_sha256_hex(asset_path: &Path) -> Result<String, UpdateError> {
         hasher.update(&buffer[..read]);
     }
 
-    Ok(hex::encode(hasher.finalize()))
+    let digest = hasher.finalize();
+    let mut hex_output = String::with_capacity(digest.len() * 2);
+
+    for byte in digest {
+        hex_output.push(char::from(HEX_CHARS[usize::from(byte >> 4)]));
+        hex_output.push(char::from(HEX_CHARS[usize::from(byte & 0x0f)]));
+    }
+
+    Ok(hex_output)
 }
 
 /// Extract the `ropy` (or `ropy.exe`) binary from the archive and return its


### PR DESCRIPTION
## Summary

Remove the updater module's dependency on the external `hex` crate by encoding SHA-256 digests locally.

## Linked Issue

Closes #118

## Changes

- replace `hex::encode` in the updater checksum path with a small local lowercase hex encoder
- remove the unused `hex` dependency from the crate manifest and lockfile

## Testing

- [x] `scripts/precheck.sh` passes locally
- [ ] New / updated tests cover the change
- existing `compute_sha256_hex_reads_file_content_expected` test continues to validate the exact checksum output

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files
- [x] New UI components use `gpui-component`
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`)
- [x] No unrelated changes mixed in
