### PR TITLE
chore(docs): rename contribution-flow skill to be project-agnostic

### DIFF
--- a/.agents/skills/contribution-flow/SKILL.md
+++ b/.agents/skills/contribution-flow/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: ropy-contribution-flow
-description: Ropy repository contribution workflow. Use for any code change that should become a commit — adding features, fixing bugs, refactoring, or any source modification. Drives the full Issue → Branch → PR → Merge process.
+name: contribution-flow
+description: Repository contribution workflow. Use for any code change that should become a commit — adding features, fixing bugs, refactoring, or any source modification. Drives the full Issue → Branch → PR → Merge process.
 ---
 
-# Ropy Contribution Flow
+# Contribution Flow
 
-Issue → Branch → PR → Merge workflow for any code change in this repo. Coding standards live in [`AGENTS.md`](../../../AGENTS.md); this skill only covers the process.
+Issue → Branch → PR → Merge workflow for any code change in this repo. Coding standards live in the project's development guidelines (e.g. `AGENTS.md`); this skill only covers the process.
 
 ## Conventions
 
 Shared vocabulary used throughout the flow below: `<type>` and `<scope>` placeholders in every step refer back here.
 
 - **Types**: `feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert`
-- **Scopes** (top-level modules): `gui | repository | clipboard | updater | i18n | config | gpui`
+- **Scopes**: infer from the project's top-level module/directory structure (e.g. `core`, `api`, `ui`).
 - **Subject**: lowercase, imperative mood, no trailing period.
 - **Consistency**: the `<type>` must match across the Issue title, branch prefix, every commit, and the PR title. The `<scope>` is required on commits and the PR title, optional on the Issue title, and omitted from the branch name.
 
@@ -20,10 +20,10 @@ Shared vocabulary used throughout the flow below: `<type>` and `<scope>` placeho
 
 ### 1. Open the Issue
 
-Pick a template from `.github/ISSUE_TEMPLATE/`. Fill it into `/tmp/ropy-issue.md`, then:
+If the project has issue templates (`.github/ISSUE_TEMPLATE/`), pick the appropriate one. Otherwise use a concise description with acceptance criteria. Fill it into `/tmp/issue-body.md`, then:
 
 ```bash
-gh issue create --title "<type>: ..." --label "<from yml>" --body-file /tmp/ropy-issue.md
+gh issue create --title "<type>: ..." --label "<appropriate label>" --body-file /tmp/issue-body.md
 ```
 
 Capture the returned number as `<N>`.
@@ -39,7 +39,7 @@ git checkout -b <type>/<kebab-slug> # e.g. feat/grid-layout, fix/clipboard-empty
 
 ### 3. Implement
 
-Follow `AGENTS.md`.
+Follow the project's development guidelines.
 
 ### 4. Precheck
 
@@ -61,11 +61,11 @@ Multiple commits are fine — they are squashed on merge.
 
 ### 6. Push & Open the PR
 
-Fill `.github/PULL_REQUEST_TEMPLATE.md` into `/tmp/ropy-pr.md`, then:
+If the project has a PR template (`.github/PULL_REQUEST_TEMPLATE.md`), fill it into `/tmp/pr-body.md`. Otherwise write a concise summary with a test plan. Then:
 
 ```bash
 git push -u origin HEAD
-gh pr create --base main --title "<type>(<scope>): ..." --body-file /tmp/ropy-pr.md
+gh pr create --base main --title "<type>(<scope>): ..." --body-file /tmp/pr-body.md
 ```
 
 Report the PR URL back to the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,6 @@
 
 ## AI Collaboration Workflow
 
-Any code change in this repository — by a human or an AI agent — MUST follow the contribution SOP defined in the [`ropy-contribution-flow`](./.agents/skills/ropy-contribution-flow/SKILL.md) skill.
+Any code change in this repository — by a human or an AI agent — MUST follow the contribution SOP defined in the [`contribution-flow`](./.agents/skills/contribution-flow/SKILL.md) skill.
 
 That skill is the single source of truth for: when to open an Issue, branch naming, Conventional Commits rules, the `scripts/precheck.sh` gate, the `gh` command templates, and the PR self-check. Read it before making any commit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ See the [Testing Documentation](./docs/TESTING.md) for guidelines on writing and
 
 ## Submitting Changes
 
-Ropy follows an **Issue → Branch → PR → Squash Merge** workflow, executed via the local `gh` CLI. The complete, copy-paste-ready SOP lives in the [`ropy-contribution-flow`](./.claude/skills/ropy-contribution-flow/SKILL.md) skill — it is the single source of truth for branch naming, commit conventions, the `scripts/precheck.sh` gate, and the PR self-check. Both human and AI contributors should follow it.
+Ropy follows an **Issue → Branch → PR → Squash Merge** workflow, executed via the local `gh` CLI. The complete, copy-paste-ready SOP lives in the [`contribution-flow`](./.agents/skills/contribution-flow/SKILL.md) skill — it is the single source of truth for branch naming, commit conventions, the `scripts/precheck.sh` gate, and the PR self-check. Both human and AI contributors should follow it.
 
 ## Reporting Issues
 

--- a/docs/CONTRIBUTING/CONTRIBUTING_ZH.md
+++ b/docs/CONTRIBUTING/CONTRIBUTING_ZH.md
@@ -66,7 +66,7 @@ Ropy 支持多语言国际化（i18n）。语言文件同样使用 TOML 格式�
 
 ## 提交规范
 
-Ropy 采用 **Issue → 分支 → PR → Squash Merge** 的工作流，全程通过本地 `gh` CLI 完成。完整、可直接复制执行的 SOP 收敛在 [`ropy-contribution-flow`](../../.claude/skills/ropy-contribution-flow/SKILL.md) skill 中 —— 那里是分支命名、commit 规范、`scripts/precheck.sh` 检查、PR 自检清单的唯一权威来源。无论人类还是 AI 贡献者，都请遵循该 skill。
+Ropy 采用 **Issue → 分支 → PR → Squash Merge** 的工作流，全程通过本地 `gh` CLI 完成。完整、可直接复制执行的 SOP 收敛在 [`contribution-flow`](../../.agents/skills/contribution-flow/SKILL.md) skill 中 —— 那里是分支命名、commit 规范、`scripts/precheck.sh` 检查、PR 自检清单的唯一权威来源。无论人类还是 AI 贡献者，都请遵循该 skill。
 
 ## 问题反馈
 


### PR DESCRIPTION
## Summary

Rename the `ropy-contribution-flow` skill to `contribution-flow` and make its content project-agnostic, removing hardcoded ropy-specific scopes and paths.

## Linked Issue

Closes #120

## Changes

- Renamed skill directory from `.agents/skills/ropy-contribution-flow/` to `.agents/skills/contribution-flow/`
- Made skill content generic (removed hardcoded scopes, replaced with inference guidance)
- Updated references in `AGENTS.md`, `CONTRIBUTING.md`, and `docs/CONTRIBUTING/CONTRIBUTING_ZH.md`

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] New / updated tests cover the change (N/A — docs-only change)

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files (N/A)
- [x] New UI components use `gpui-component` (N/A)
- [x] Errors defined with `thiserror` (N/A)
- [x] No unrelated changes mixed in
