### PR TITLE
refactor(gui): hoist background color onto shared base builder

### DIFF
--- a/src/gui/board/render.rs
+++ b/src/gui/board/render.rs
@@ -14,6 +14,8 @@ use crate::gui::panel::{
 
 impl Render for RopyBoard {
     fn render(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement {
+        let surface_bg = self.main_panel_surface(cx.theme().background);
+
         let base = v_flex()
             .id("ropy-board")
             .track_focus(&self.focus_handle)
@@ -22,31 +24,23 @@ impl Render for RopyBoard {
             .on_action(cx.listener(Self::on_active_action))
             .size_full()
             .px_4()
-            .pb_4();
+            .pb_4()
+            .bg(surface_bg);
 
         if !self.activated {
-            return gpui::div()
-                .size_full()
-                .child(base.bg(self.main_panel_surface(cx.theme().background)))
-                .into_any_element();
+            return gpui::div().size_full().child(base).into_any_element();
         }
 
         let body: AnyElement = match self.active_panel {
             ActivePanel::Settings => base
-                .bg(self.main_panel_surface(cx.theme().background))
                 .on_key_down(cx.listener(Self::on_settings_key_down))
                 .child(render_settings_content(self, cx))
                 .into_any_element(),
             ActivePanel::About => base
-                .bg(self.main_panel_surface(cx.theme().background))
                 .child(render_about_content(self, cx))
                 .into_any_element(),
-            ActivePanel::Help => base
-                .bg(self.main_panel_surface(cx.theme().background))
-                .child(render_help_content(self, cx))
-                .into_any_element(),
+            ActivePanel::Help => base.child(render_help_content(self, cx)).into_any_element(),
             ActivePanel::ClipboardList => base
-                .bg(self.main_panel_surface(cx.theme().background))
                 .on_action(cx.listener(Self::on_select_left))
                 .on_action(cx.listener(Self::on_select_right))
                 .on_action(cx.listener(Self::on_select_prev))


### PR DESCRIPTION
## Summary

Deduplicate the repeated `.bg(self.main_panel_surface(...))` call by computing `surface_bg` once and applying it on the shared `base` builder.

## Linked Issue

Closes #130

## Changes

- Compute `surface_bg` at the top of `Render::render` and chain `.bg(surface_bg)` onto `base`.
- Remove 4 redundant per-arm `.bg(...)` calls (Settings, About, Help, ClipboardList) and the deactivated-state duplicate.

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] New / updated tests cover the change — N/A (purely mechanical, existing tests pass)

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`)
- [x] No unrelated changes mixed in
