### PR TITLE
fix(scripts): authenticate git-cliff with gh token

### DIFF
--- a/scripts/release_prepare.sh
+++ b/scripts/release_prepare.sh
@@ -30,7 +30,13 @@ perl -i -0777 -pe "s/(\[package\.metadata\.bundle\.bin\.ropy\]\n(?:.*\n)*?versio
 ./scripts/record_build_size.sh
 
 # Generate changelog for the new release
-git cliff --unreleased --tag "$release_version" --prepend CHANGELOG.md
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+	if ! GITHUB_TOKEN="$(gh auth token)"; then
+		echo "Error: failed to get a GitHub token from gh; run 'gh auth login' first." >&2
+		exit 1
+	fi
+fi
+GITHUB_TOKEN="$GITHUB_TOKEN" git cliff --unreleased --tag "$release_version" --prepend CHANGELOG.md
 # Remove HTML comment markers (e.g., <!-- 0 -->) from CHANGELOG.md
 # These markers are added by git-cliff as placeholders for version numbers
 perl -i -pe 's/<!-- \d+ -->//g' CHANGELOG.md


### PR DESCRIPTION
## Summary

Authenticate git-cliff during release preparation by reusing `GITHUB_TOKEN` or falling back to the token stored by GitHub CLI. This prevents anonymous GitHub API requests from failing with HTTP 403.

## Linked Issue

Closes #145

## Changes

- Preserve an explicitly provided `GITHUB_TOKEN`.
- Resolve the active token with `gh auth token` when the environment variable is absent, with a clear login error on failure.

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] Verified an authenticated `git cliff --unreleased` metadata fetch with `GITHUB_TOKEN` initially unset

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded application UI strings introduced
- [x] No Rust error types introduced
- [x] No unrelated changes mixed in
