### PR TITLE
fix(updater): avoid anonymous API rate limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,16 +322,24 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Generate update manifest
+        env:
+          RELEASE_TAG: "${{ needs.plan.outputs.tag }}"
+          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
+        run: |
+          printf '%s' "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
+          bash scripts/generate_update_manifest.sh \
+            artifacts \
+            "$GITHUB_REPOSITORY" \
+            "$RELEASE_TAG" \
+            "$RUNNER_TEMP/notes.txt" \
+            artifacts/latest.json
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
-
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
   announce:

--- a/assets/locales/en.toml
+++ b/assets/locales/en.toml
@@ -90,6 +90,7 @@ update_restart = "Update installed. Restart to apply."
 update_restart_button = "Restart Now"
 update_error = "Update check failed"
 update_error_network = "Network connection failed, please check your network settings"
+update_error_rate_limited = "GitHub is limiting update checks. Please try again later"
 
 # Help / Keyboard shortcuts
 help_title = "Keyboard Shortcuts"

--- a/assets/locales/ja.toml
+++ b/assets/locales/ja.toml
@@ -91,6 +91,7 @@ update_restart = "アップデートがインストールされました。再�
 update_restart_button = "今すぐ再起動"
 update_error = "アップデート確認に失敗しました"
 update_error_network = "ネットワーク接続に失敗しました。ネットワーク設定を確認してください"
+update_error_rate_limited = "GitHub がアップデート確認を制限しています。しばらくしてから再試行してください"
 
 # ヘルプ / キーボードショートカット
 help_title = "キーボードショートカット"

--- a/assets/locales/zh-CN.toml
+++ b/assets/locales/zh-CN.toml
@@ -91,6 +91,7 @@ update_restart = "更新已安装，重启后生效。"
 update_restart_button = "立即重启"
 update_error = "检查更新失败"
 update_error_network = "网络连接失败，请检查网络设置"
+update_error_rate_limited = "GitHub 更新检查请求受限，请稍后重试"
 
 # 帮助 / 快捷键
 help_title = "快捷键说明"

--- a/scripts/generate_update_manifest.sh
+++ b/scripts/generate_update_manifest.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 5 ]]; then
+	echo "Usage: $0 <artifact-dir> <repository> <tag> <notes-file> <output>" >&2
+	exit 2
+fi
+
+artifact_dir="$1"
+repository="$2"
+tag="$3"
+notes_file="$4"
+output="$5"
+assets='[]'
+
+append_asset() {
+	local path="$1"
+	local name="${path##*/}"
+	local size
+	local url
+
+	size="$(wc -c <"$path" | tr -d ' ')"
+	url="https://github.com/${repository}/releases/download/${tag}/${name}"
+	assets="$(
+		jq -c \
+			--arg name "$name" \
+			--arg url "$url" \
+			--argjson size "$size" \
+			'. + [{name: $name, browser_download_url: $url, size: $size}]' \
+			<<<"$assets"
+	)"
+}
+
+while IFS= read -r -d '' archive; do
+	append_asset "$archive"
+	if [[ -f "${archive}.sha256" ]]; then
+		append_asset "${archive}.sha256"
+	fi
+done < <(
+	find "$artifact_dir" -maxdepth 1 -type f \
+		\( -name 'ropy-*.tar.xz' -o -name 'ropy-*.zip' \) \
+		-print0 | sort -z
+)
+
+if [[ "$assets" == '[]' ]]; then
+	echo "No update archives found in $artifact_dir" >&2
+	exit 1
+fi
+
+jq -n \
+	--arg tag "$tag" \
+	--rawfile body "$notes_file" \
+	--argjson assets "$assets" \
+	'{tag_name: $tag, body: $body, assets: $assets}' \
+	>"$output"

--- a/src/gui/board/settings_editor.rs
+++ b/src/gui/board/settings_editor.rs
@@ -122,6 +122,15 @@ impl UpdateManager {
             status: crate::updater::models::UpdateStatus::Idle,
         }
     }
+
+    pub(super) fn begin_check(&mut self) -> bool {
+        if matches!(self.status, crate::updater::models::UpdateStatus::Checking) {
+            return false;
+        }
+
+        self.status = crate::updater::models::UpdateStatus::Checking;
+        true
+    }
 }
 
 pub(super) fn build_window_opacity_slider(

--- a/src/gui/board/tests.rs
+++ b/src/gui/board/tests.rs
@@ -108,6 +108,15 @@ fn test_update_manager_new_starts_idle() {
 }
 
 #[test]
+fn test_update_manager_begin_check_ignores_duplicate_in_flight_request() {
+    let mut manager = UpdateManager::new();
+
+    assert!(manager.begin_check());
+    assert!(matches!(manager.status, UpdateStatus::Checking));
+    assert!(!manager.begin_check());
+}
+
+#[test]
 fn test_preview_state_is_visible_only_while_space_is_held() {
     let mut ui_state = UiState::default();
 

--- a/src/gui/board/updater_ui.rs
+++ b/src/gui/board/updater_ui.rs
@@ -8,7 +8,9 @@ use crate::{
 
 impl RopyBoard {
     pub(crate) fn check_for_update_async(&mut self, cx: &mut Context<'_, Self>) {
-        self.update_manager.status = UpdateStatus::Checking;
+        if !self.update_manager.begin_check() {
+            return;
+        }
         cx.notify();
 
         let include_prerelease = Settings::read(cx, |s| s.update.include_prerelease);

--- a/src/gui/panel/about.rs
+++ b/src/gui/panel/about.rs
@@ -146,7 +146,9 @@ fn render_update_section(board: &RopyBoard, cx: &Context<'_, RopyBoard>) -> impl
             // Surface a localized "network problem" hint for the most common
             // class of update failures so users aren't shown raw curl /
             // TLS errors.
-            let friendly_msg = if msg.contains("curl")
+            let friendly_msg = if msg.to_ascii_lowercase().contains("rate limit") {
+                I18n::translate(cx, "update_error_rate_limited")
+            } else if msg.contains("curl")
                 || msg.contains("SSL")
                 || msg.contains("HTTP request failed")
             {

--- a/src/updater/checker.rs
+++ b/src/updater/checker.rs
@@ -1,4 +1,4 @@
-//! Version checker – queries GitHub Releases API and compares versions.
+//! Version checker – discovers GitHub releases and compares versions.
 
 use semver::Version;
 
@@ -16,6 +16,10 @@ const TARGET: &str = env!("TARGET");
 
 /// Current crate version from `Cargo.toml`
 const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn stable_release_manifest_url() -> String {
+    format!("https://github.com/{REPO_OWNER}/{REPO_NAME}/releases/latest/download/latest.json")
+}
 
 /// Return the expected asset filename for the given target triple.
 fn expected_asset_name(target: &str) -> String {
@@ -35,22 +39,31 @@ pub(crate) fn check_for_update(
     include_prerelease: bool,
 ) -> Result<Option<ReleaseInfo>, UpdateError> {
     let release = fetch_latest_release(include_prerelease)?;
-    let latest_version = parse_version(&release.tag_name)?;
     let current_version =
         Version::parse(CURRENT_VERSION).map_err(|e| UpdateError::Parse(e.to_string()))?;
 
-    if latest_version <= current_version {
+    resolve_release(release, &current_version, TARGET)
+}
+
+fn resolve_release(
+    release: GitHubRelease,
+    current_version: &Version,
+    target: &str,
+) -> Result<Option<ReleaseInfo>, UpdateError> {
+    let latest_version = parse_version(&release.tag_name)?;
+
+    if latest_version <= *current_version {
         return Ok(None);
     }
 
-    let asset_name = expected_asset_name(TARGET);
+    let asset_name = expected_asset_name(target);
     let checksum_name = format!("{asset_name}.sha256");
 
     let asset = release
         .assets
         .iter()
         .find(|a| a.name == asset_name)
-        .ok_or_else(|| UpdateError::NoCompatibleAsset(TARGET.to_string()))?;
+        .ok_or_else(|| UpdateError::NoCompatibleAsset(target.to_string()))?;
 
     let checksum_asset = release.assets.iter().find(|a| a.name == checksum_name);
 
@@ -67,10 +80,11 @@ pub(crate) fn check_for_update(
     }))
 }
 
-/// Fetch the latest (non-prerelease by default) release from GitHub.
+/// Fetch the latest release manifest.
 fn fetch_latest_release(include_prerelease: bool) -> Result<GitHubRelease, UpdateError> {
     if include_prerelease {
-        // Need to list releases and pick the first one (which is the latest)
+        // GitHub's stable release redirect excludes prereleases, so the
+        // opt-in prerelease path still uses the rate-limited API.
         let url =
             format!("https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/releases?per_page=10");
         let body = http_get(&url)?;
@@ -81,8 +95,7 @@ fn fetch_latest_release(include_prerelease: bool) -> Result<GitHubRelease, Updat
             .next()
             .ok_or_else(|| UpdateError::Parse("no releases found".into()))
     } else {
-        let url = format!("https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/releases/latest");
-        let body = http_get(&url)?;
+        let body = http_get(&stable_release_manifest_url())?;
         serde_json::from_str(&body).map_err(|e| UpdateError::Parse(e.to_string()))
     }
 }
@@ -149,6 +162,50 @@ mod tests {
     fn test_expected_asset_name_linux() {
         let name = expected_asset_name("x86_64-unknown-linux-gnu");
         assert_eq!(name, "ropy-x86_64-unknown-linux-gnu.tar.xz");
+    }
+
+    #[test]
+    fn test_stable_manifest_url_avoids_github_api() {
+        let url = stable_release_manifest_url();
+        assert_eq!(
+            url,
+            "https://github.com/StudentWeis/ropy/releases/latest/download/latest.json"
+        );
+        assert!(!url.contains("api.github.com"));
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_resolve_release_manifest_for_matching_target_returns_download_info() {
+        let release: GitHubRelease = serde_json::from_str(
+            r#"{
+                "tag_name": "0.6.0",
+                "body": "Rate-limit resistant updates",
+                "assets": [
+                    {
+                        "name": "ropy-aarch64-apple-darwin.tar.xz",
+                        "browser_download_url": "https://github.com/StudentWeis/ropy/releases/download/0.6.0/ropy-aarch64-apple-darwin.tar.xz",
+                        "size": 4096
+                    },
+                    {
+                        "name": "ropy-aarch64-apple-darwin.tar.xz.sha256",
+                        "browser_download_url": "https://github.com/StudentWeis/ropy/releases/download/0.6.0/ropy-aarch64-apple-darwin.tar.xz.sha256",
+                        "size": 99
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let info = resolve_release(release, &Version::new(0, 5, 4), "aarch64-apple-darwin")
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(info.version, "0.6.0");
+        assert_eq!(info.release_notes, "Rate-limit resistant updates");
+        assert_eq!(info.asset_size, 4096);
+        assert!(info.download_url.ends_with(".tar.xz"));
+        assert!(info.checksum_url.ends_with(".tar.xz.sha256"));
     }
 
     // ── parse_version Error Cases ─────────────────────────────────

--- a/src/updater/errors.rs
+++ b/src/updater/errors.rs
@@ -7,6 +7,9 @@ pub(crate) enum UpdateError {
     #[error("network request failed: {0}")]
     Network(String),
 
+    #[error("GitHub API rate limit exceeded; please try again later")]
+    RateLimited,
+
     #[error("failed to parse release info: {0}")]
     Parse(String),
 

--- a/src/updater/http.rs
+++ b/src/updater/http.rs
@@ -16,6 +16,14 @@ pub(crate) struct CurlCommandBuilder {
     command: Command,
 }
 
+#[derive(Debug)]
+struct CurlOutput {
+    success: bool,
+    status: String,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+}
+
 impl CurlCommandBuilder {
     pub(crate) fn new(url: &str) -> Self {
         let mut command = Command::new("curl");
@@ -60,9 +68,24 @@ impl CurlCommandBuilder {
     /// Run to completion, capture the final HTTP status, and decode stdout as
     /// UTF-8. HTTP failures retain their response body so callers can
     /// distinguish service rate limits from connection failures.
-    pub(crate) fn execute_to_string(mut self) -> Result<String, UpdateError> {
+    pub(crate) fn execute_to_string(self) -> Result<String, UpdateError> {
+        self.execute_with(|command| {
+            let output = command.output()?;
+            Ok(CurlOutput {
+                success: output.status.success(),
+                status: output.status.to_string(),
+                stdout: output.stdout,
+                stderr: output.stderr,
+            })
+        })
+    }
+
+    fn execute_with(
+        mut self,
+        runner: impl FnOnce(&mut Command) -> std::io::Result<CurlOutput>,
+    ) -> Result<String, UpdateError> {
         self.command.args(["--write-out", HTTP_STATUS_WRITE_OUT]);
-        let output = self.command.output().map_err(|e| {
+        let output = runner(&mut self.command).map_err(|e| {
             tracing::error!(error = %e, "failed to launch curl");
             UpdateError::Network(format!("failed to launch curl: {e}"))
         })?;
@@ -72,13 +95,13 @@ impl CurlCommandBuilder {
             UpdateError::Network(format!("invalid UTF-8 in response: {e}"))
         })?;
 
-        if !output.status.success() {
+        if !output.success {
             let body = stdout
                 .rsplit_once(HTTP_STATUS_MARKER)
                 .map_or(stdout.as_str(), |(body, _)| body);
             let stderr = String::from_utf8_lossy(&output.stderr);
             tracing::error!(status = %output.status, stderr = %stderr, body = %body, "curl request failed");
-            return Err(curl_failure(&output.status.to_string(), body, &stderr));
+            return Err(curl_failure(&output.status, body, &stderr));
         }
 
         let (body, http_status) = parse_http_response(&stdout)?;
@@ -127,6 +150,24 @@ fn curl_failure(status: &str, body: &str, stderr: &str) -> UpdateError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn request_mock(http_status: u16, body: &str) -> Result<String, UpdateError> {
+        let output = CurlOutput {
+            success: true,
+            status: "exit status: 0".to_string(),
+            stdout: format!("{body}{HTTP_STATUS_MARKER}{http_status}").into_bytes(),
+            stderr: Vec::new(),
+        };
+
+        CurlCommandBuilder::new("https://mock.invalid/release").execute_with(|command| {
+            let args = command_args(command);
+            assert!(
+                args.windows(2)
+                    .any(|pair| pair == ["--write-out", HTTP_STATUS_WRITE_OUT])
+            );
+            Ok(output)
+        })
+    }
 
     fn command_args(command: &Command) -> Vec<String> {
         command
@@ -182,5 +223,24 @@ mod tests {
 
         assert_eq!(body, r#"{"tag_name":"0.6.0"}"#);
         assert_eq!(status, 200);
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_execute_to_string_when_mock_returns_success_returns_response_body() {
+        let expected = r#"{"tag_name":"0.6.0","body":"Mock release","assets":[]}"#;
+
+        let actual = request_mock(200, expected).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_execute_to_string_when_mock_returns_rate_limit_returns_rate_limited_error() {
+        let body = r#"{"message":"API rate limit exceeded for 192.0.2.1."}"#;
+
+        let result = request_mock(403, body);
+
+        assert!(matches!(result, Err(UpdateError::RateLimited)));
     }
 }

--- a/src/updater/http.rs
+++ b/src/updater/http.rs
@@ -9,6 +9,8 @@ use super::errors::UpdateError;
 pub(crate) const CONNECT_TIMEOUT_SECS: u32 = 15;
 pub(crate) const API_REQUEST_MAX_TIME_SECS: u32 = 30;
 pub(crate) const DOWNLOAD_REQUEST_MAX_TIME_SECS: u32 = 600;
+const HTTP_STATUS_MARKER: &str = "__ROPY_HTTP_STATUS__:";
+const HTTP_STATUS_WRITE_OUT: &str = "__ROPY_HTTP_STATUS__:%{http_code}";
 
 pub(crate) struct CurlCommandBuilder {
     command: Command,
@@ -19,7 +21,6 @@ impl CurlCommandBuilder {
         let mut command = Command::new("curl");
         command.args([
             "-sSL",
-            "--fail",
             "-H",
             &format!("User-Agent: ropy/{}", env!("CARGO_PKG_VERSION")),
         ]);
@@ -56,36 +57,71 @@ impl CurlCommandBuilder {
             .max_time(DOWNLOAD_REQUEST_MAX_TIME_SECS)
     }
 
-    /// Run to completion and decode stdout as UTF-8. Failures (non-zero
-    /// exit, non-UTF-8 body) are mapped to [`UpdateError::Network`] and
-    /// logged, since every callsite would otherwise repeat the same code.
+    /// Run to completion, capture the final HTTP status, and decode stdout as
+    /// UTF-8. HTTP failures retain their response body so callers can
+    /// distinguish service rate limits from connection failures.
     pub(crate) fn execute_to_string(mut self) -> Result<String, UpdateError> {
+        self.command.args(["--write-out", HTTP_STATUS_WRITE_OUT]);
         let output = self.command.output().map_err(|e| {
             tracing::error!(error = %e, "failed to launch curl");
             UpdateError::Network(format!("failed to launch curl: {e}"))
         })?;
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            tracing::error!(status = %output.status, stderr = %stderr, "curl request failed");
-            return Err(UpdateError::Network(format!(
-                "HTTP request failed (exit {}): {stderr}",
-                output.status
-            )));
-        }
-
-        String::from_utf8(output.stdout).map_err(|e| {
+        let stdout = String::from_utf8(output.stdout).map_err(|e| {
             tracing::error!(error = %e, "response body is not valid UTF-8");
             UpdateError::Network(format!("invalid UTF-8 in response: {e}"))
-        })
+        })?;
+
+        if !output.status.success() {
+            let body = stdout
+                .rsplit_once(HTTP_STATUS_MARKER)
+                .map_or(stdout.as_str(), |(body, _)| body);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::error!(status = %output.status, stderr = %stderr, body = %body, "curl request failed");
+            return Err(curl_failure(&output.status.to_string(), body, &stderr));
+        }
+
+        let (body, http_status) = parse_http_response(&stdout)?;
+        if !(200..300).contains(&http_status) {
+            tracing::error!(status = http_status, body = %body, "HTTP request failed");
+            return Err(curl_failure(&format!("HTTP {http_status}"), body, ""));
+        }
+
+        Ok(body.to_string())
     }
 
     /// Escape hatch for callers that need piped stdio (streaming downloads
     /// with progress tracking) and therefore can't go through
     /// [`Self::execute_to_string`].
-    pub(crate) fn into_command(self) -> Command {
+    pub(crate) fn into_command(mut self) -> Command {
+        self.command.arg("--fail");
         self.command
     }
+}
+
+fn parse_http_response(response: &str) -> Result<(&str, u16), UpdateError> {
+    let (body, status) = response.rsplit_once(HTTP_STATUS_MARKER).ok_or_else(|| {
+        UpdateError::Network("curl response did not include an HTTP status".into())
+    })?;
+    let status = status
+        .parse()
+        .map_err(|e| UpdateError::Network(format!("invalid HTTP status '{status}': {e}")))?;
+    Ok((body, status))
+}
+
+fn curl_failure(status: &str, body: &str, stderr: &str) -> UpdateError {
+    if body.to_ascii_lowercase().contains("rate limit exceeded") {
+        return UpdateError::RateLimited;
+    }
+
+    let body = body.trim();
+    let detail = if body.is_empty() {
+        stderr.trim().to_string()
+    } else {
+        body.chars().take(512).collect()
+    };
+
+    UpdateError::Network(format!("HTTP request failed ({status}): {detail}"))
 }
 
 #[cfg(test)]
@@ -125,5 +161,26 @@ mod tests {
                 .any(|pair| pair == ["--connect-timeout", "15"])
         );
         assert!(args.windows(2).any(|pair| pair == ["--max-time", "600"]));
+    }
+
+    #[test]
+    fn test_curl_failure_with_github_rate_limit_body_returns_rate_limited_error() {
+        let error = curl_failure(
+            "exit status: 22",
+            r#"{"message":"API rate limit exceeded for 192.0.2.1."}"#,
+            "curl: (22) The requested URL returned error: 403",
+        );
+
+        assert!(matches!(error, UpdateError::RateLimited));
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_parse_http_response_separates_body_and_status() {
+        let (body, status) =
+            parse_http_response(r#"{"tag_name":"0.6.0"}__ROPY_HTTP_STATUS__:200"#).unwrap();
+
+        assert_eq!(body, r#"{"tag_name":"0.6.0"}"#);
+        assert_eq!(status, 200);
     }
 }


### PR DESCRIPTION
## Summary

Move stable update discovery off the anonymous GitHub REST API and onto a release-hosted `latest.json` manifest, preventing shared-IP API quota exhaustion from breaking update checks. Preserve response bodies for explicit rate-limit classification and suppress duplicate in-flight checks.

## Linked Issue

Closes #149

## Changes

- Generate and upload a GitHub Release-compatible `latest.json` manifest for every release, including platform archives and checksums.
- Resolve stable updates from the release download endpoint while retaining the API path for opt-in prereleases.
- Capture HTTP status and error bodies with portable curl flags, classify GitHub rate limits, and show localized messages.
- Ignore duplicate update requests while a check is already running.
- Add coverage for manifest routing/resolution, HTTP response parsing, rate-limit classification, and duplicate checks.

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] New / updated tests cover the change
- [x] Update manifest generator smoke-tested with archive and checksum fixtures
- [x] Release workflow YAML parsed successfully

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`)
- [x] No unrelated changes mixed in
