### PR TITLE
fix(gui): open history from tray left-click

### DIFF
--- a/src/gui/tray.rs
+++ b/src/gui/tray.rs
@@ -126,6 +126,7 @@ fn load_tray_icon_rgba(bytes: &[u8]) -> Result<(Vec<u8>, u32, u32), image::Image
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TrayEvent {
+    Show,
     Settings,
     About,
     Quit,
@@ -183,6 +184,9 @@ fn spawn_tray_event_loop(
     cx.spawn(async move |async_app| {
         while let Ok(event) = rx.recv().await {
             match event {
+                TrayEvent::Show => {
+                    let _ = async_app.update(|cx| send_active_action(window_handle, cx));
+                }
                 TrayEvent::Settings => {
                     let _ = async_app.update(|cx| send_open_settings(window_handle, cx));
                 }
@@ -217,6 +221,14 @@ pub(crate) fn start_tray_handler_inner(
             None
         }
     }
+}
+
+fn send_active_action(window_handle: WindowHandle<Root>, cx: &mut App) {
+    window_handle
+        .update(cx, |_, window: &mut gpui::Window, cx| {
+            window.dispatch_action(Box::new(crate::gui::board::Active), cx);
+        })
+        .ok();
 }
 
 pub(crate) fn send_open_settings(window_handle: WindowHandle<Root>, cx: &mut App) {
@@ -317,7 +329,7 @@ fn tray_event_from_icon_event(event: &TrayIconEvent) -> Option<TrayEvent> {
     if let TrayIconEvent::Click { button, .. } = event
         && *button == tray_icon::MouseButton::Left
     {
-        Some(TrayEvent::Settings)
+        Some(TrayEvent::Show)
     } else {
         None
     }
@@ -403,7 +415,7 @@ mod tests {
             button: tray_icon::MouseButton::Left,
             button_state: tray_icon::MouseButtonState::Up,
         },
-        Some(TrayEvent::Settings)
+        Some(TrayEvent::Show)
     )]
     #[case(
         TrayIconEvent::Click {


### PR DESCRIPTION
## Summary

Restore the tray icon's primary action so a left-click opens the clipboard history window instead of Settings.

## Linked Issue

Closes #153

## Changes

- Map non-Linux tray left-click events to a dedicated `Show` event.
- Reuse the existing board `Active` action so activation returns to the clipboard list while preserving Settings and About menu behavior.
- Update the tray event test to cover the restored mapping.

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] New / updated tests cover the change

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`)
- [x] No unrelated changes mixed in
