### PR TITLE
fix(core): resolve repository quality audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5711,7 +5711,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serial_test",
  "sha2 0.11.0",
  "tar",
  "tempfile",
@@ -6264,31 +6263,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serial_test"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,6 @@ image = { version = "0.25.10", default-features = false, features = [
 
 [dev-dependencies]
 rstest = "0.26.1"
-serial_test = "4.0.1"
 
 [lints.rust]
 # Code quality

--- a/assets/locales/en.toml
+++ b/assets/locales/en.toml
@@ -32,6 +32,8 @@ filter_files = "Filter files"
 filter_favorites = "Filter favorites"
 search_case_sensitive = "Case-sensitive"
 search_match_whole_word = "Whole word"
+record_file_empty = "File"
+record_file_count = "{count} files"
 # Settings
 settings_button = "Settings"
 settings_title = "Settings"

--- a/assets/locales/ja.toml
+++ b/assets/locales/ja.toml
@@ -33,6 +33,8 @@ filter_files = "ファイルをフィルター"
 filter_favorites = "お気に入りをフィルター"
 search_case_sensitive = "大文字と小文字を区別"
 search_match_whole_word = "単語一致"
+record_file_empty = "ファイル"
+record_file_count = "{count} 個のファイル"
 # Settings
 settings_button = "設定"
 settings_title = "設定"

--- a/assets/locales/zh-CN.toml
+++ b/assets/locales/zh-CN.toml
@@ -32,6 +32,8 @@ filter_files = "筛选文件"
 filter_favorites = "筛选收藏"
 search_case_sensitive = "区分大小写"
 search_match_whole_word = "全词"
+record_file_empty = "文件"
+record_file_count = "{count} 个文件"
 # 设置
 settings_button = "设置"
 settings_title = "设置"

--- a/scripts/check/check_i18n.py
+++ b/scripts/check/check_i18n.py
@@ -51,13 +51,14 @@ def collect_used_keys(src_root: Path) -> set[str]:
 
     Recognises these call patterns:
       * I18n::translate(cx, "key")
+      * I18n::translate_count(cx, "key", count)
       * i18n.t("key")
       * translations.get("key")
       * any_field_key: "key"  (struct field ending with ``_key``, used for
                                indirect i18n lookups like ``i18n.t(row.label_key)``)
     """
     # Direct I18n::translate / .t() / .get() call patterns
-    direct_pattern = re.compile(r'I18n::translate\(\s*\w+\s*,\s*"([^"]+)"\s*\)|\.t\(\s*"([^"]+)"\s*\)|\.get\(\s*"([^"]+)"\s*\)')
+    direct_pattern = re.compile(r'I18n::translate(?:_count)?\(\s*\w+\s*,\s*"([^"]+)"|\.t\(\s*"([^"]+)"\s*\)|\.get\(\s*"([^"]+)"\s*\)')
     # Struct field whose name ends with ``_key`` assigned a string literal,
     # e.g. ``label_key: "help_search"``
     field_key_pattern = re.compile(r'\b\w+_key\s*:\s*"([^"]+)"')

--- a/scripts/generate_update_manifest.sh
+++ b/scripts/generate_update_manifest.sh
@@ -33,9 +33,11 @@ append_asset() {
 
 while IFS= read -r -d '' archive; do
 	append_asset "$archive"
-	if [[ -f "${archive}.sha256" ]]; then
-		append_asset "${archive}.sha256"
+	if [[ ! -f "${archive}.sha256" ]]; then
+		echo "Missing checksum for update archive: ${archive}.sha256" >&2
+		exit 1
 	fi
+	append_asset "${archive}.sha256"
 done < <(
 	find "$artifact_dir" -maxdepth 1 -type f \
 		\( -name 'ropy-*.tar.xz' -o -name 'ropy-*.zip' \) \

--- a/scripts/precheck.sh
+++ b/scripts/precheck.sh
@@ -29,6 +29,7 @@ fi
 $CARGO_CMD check --all-targets --all-features
 $CARGO_CMD clippy --all-targets --all-features
 $CARGO_CMD test
+RUSTDOCFLAGS="-D warnings" $CARGO_CMD doc --no-deps
 
 # Check unused dependencies
 if command -v cargo-machete &>/dev/null; then

--- a/src/app.rs
+++ b/src/app.rs
@@ -250,11 +250,7 @@ fn load_settings() -> Settings {
         }
         Err(e) => {
             tracing::warn!(error = %e, "failed to load settings; using defaults");
-            let default_settings = Settings::default();
-            default_settings.save().unwrap_or_else(|err| {
-                tracing::error!(error = %err, "failed to save default settings");
-            });
-            default_settings
+            Settings::default()
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 #[cfg(target_os = "linux")]
+/// Shared X11 connection used for native window mapping and activation.
 pub static X11_INSTANCE: OnceLock<X11> = OnceLock::new();
 
 /// Capacity for the clipboard event channel between the OS clipboard listener

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -1,5 +1,7 @@
 use std::sync::mpsc::Sender as CompletionSender;
 
+use thiserror::Error;
+
 /// Clipboard event monitoring and ingestion.
 pub mod listener;
 /// Clipboard asset persistence helpers.
@@ -26,24 +28,36 @@ pub(crate) enum ClipboardEvent {
     },
 }
 
+pub(crate) type ClipboardWriteResult = Result<(), ClipboardWriteError>;
+
+#[derive(Debug, Error)]
+pub(crate) enum ClipboardWriteError {
+    #[error("clipboard operation failed: {0}")]
+    Clipboard(String),
+    #[error("failed to load clipboard image: {0}")]
+    Image(#[from] image::ImageError),
+    #[error("cannot copy an empty file list")]
+    EmptyFileList,
+}
+
 pub(crate) enum CopyRequest {
     Text {
         text: String,
-        completion: Option<CompletionSender<()>>,
+        completion: Option<CompletionSender<ClipboardWriteResult>>,
     },
     Image {
         path: String,
-        completion: Option<CompletionSender<()>>,
+        completion: Option<CompletionSender<ClipboardWriteResult>>,
     },
     Files {
         paths: Vec<String>,
-        completion: Option<CompletionSender<()>>,
+        completion: Option<CompletionSender<ClipboardWriteResult>>,
     },
     RichText {
         plain_text: String,
         html: Option<String>,
         rtf: Option<String>,
-        completion: Option<CompletionSender<()>>,
+        completion: Option<CompletionSender<ClipboardWriteResult>>,
     },
 }
 
@@ -57,7 +71,7 @@ impl CopyRequest {
 
     pub(crate) const fn text_with_completion(
         text: String,
-        completion: CompletionSender<()>,
+        completion: CompletionSender<ClipboardWriteResult>,
     ) -> Self {
         Self::Text {
             text,
@@ -74,7 +88,7 @@ impl CopyRequest {
 
     pub(crate) const fn image_with_completion(
         path: String,
-        completion: CompletionSender<()>,
+        completion: CompletionSender<ClipboardWriteResult>,
     ) -> Self {
         Self::Image {
             path,
@@ -91,7 +105,7 @@ impl CopyRequest {
 
     pub(crate) const fn files_with_completion(
         paths: Vec<String>,
-        completion: CompletionSender<()>,
+        completion: CompletionSender<ClipboardWriteResult>,
     ) -> Self {
         Self::Files {
             paths,
@@ -116,7 +130,7 @@ impl CopyRequest {
         plain_text: String,
         html: Option<String>,
         rtf: Option<String>,
-        completion: CompletionSender<()>,
+        completion: CompletionSender<ClipboardWriteResult>,
     ) -> Self {
         Self::RichText {
             plain_text,
@@ -129,6 +143,7 @@ impl CopyRequest {
 
 pub(crate) enum LastCopyState {
     Text(String),
+    RichText(u64),
     Image(u64),
     Files(u64),
 }
@@ -165,7 +180,7 @@ mod tests {
         match request {
             CopyRequest::Text { text, completion } => {
                 assert_eq!(text, "hello");
-                completion.unwrap().send(()).unwrap();
+                completion.unwrap().send(Ok(())).unwrap();
             }
             CopyRequest::Image { .. }
             | CopyRequest::Files { .. }
@@ -174,7 +189,10 @@ mod tests {
             }
         }
 
-        assert_eq!(completion_rx.recv_timeout(Duration::from_secs(1)), Ok(()));
+        assert!(matches!(
+            completion_rx.recv_timeout(Duration::from_secs(1)),
+            Ok(Ok(()))
+        ));
     }
 
     #[test]
@@ -202,14 +220,17 @@ mod tests {
         match request {
             CopyRequest::Image { path, completion } => {
                 assert_eq!(path, "/tmp/example.png");
-                completion.unwrap().send(()).unwrap();
+                completion.unwrap().send(Ok(())).unwrap();
             }
             CopyRequest::Text { .. } | CopyRequest::Files { .. } | CopyRequest::RichText { .. } => {
                 panic!("expected image copy request")
             }
         }
 
-        assert_eq!(completion_rx.recv_timeout(Duration::from_secs(1)), Ok(()));
+        assert!(matches!(
+            completion_rx.recv_timeout(Duration::from_secs(1)),
+            Ok(Ok(()))
+        ));
     }
 
     #[test]
@@ -237,14 +258,17 @@ mod tests {
         match request {
             CopyRequest::Files { paths, completion } => {
                 assert_eq!(paths, vec!["/tmp/example.txt"]);
-                completion.unwrap().send(()).unwrap();
+                completion.unwrap().send(Ok(())).unwrap();
             }
             CopyRequest::Text { .. } | CopyRequest::Image { .. } | CopyRequest::RichText { .. } => {
                 panic!("expected files copy request")
             }
         }
 
-        assert_eq!(completion_rx.recv_timeout(Duration::from_secs(1)), Ok(()));
+        assert!(matches!(
+            completion_rx.recv_timeout(Duration::from_secs(1)),
+            Ok(Ok(()))
+        ));
     }
 
     #[test]
@@ -294,13 +318,16 @@ mod tests {
                 assert_eq!(plain_text, "hello");
                 assert_eq!(html.as_deref(), Some("<p>hello</p>"));
                 assert_eq!(rtf.as_deref(), Some("{\\rtf1 hello}"));
-                completion.unwrap().send(()).unwrap();
+                completion.unwrap().send(Ok(())).unwrap();
             }
             CopyRequest::Text { .. } | CopyRequest::Image { .. } | CopyRequest::Files { .. } => {
                 panic!("expected rich text copy request")
             }
         }
 
-        assert_eq!(completion_rx.recv_timeout(Duration::from_secs(1)), Ok(()));
+        assert!(matches!(
+            completion_rx.recv_timeout(Duration::from_secs(1)),
+            Ok(Ok(()))
+        ));
     }
 }

--- a/src/clipboard/listener.rs
+++ b/src/clipboard/listener.rs
@@ -1,6 +1,9 @@
 //! A simple clipboard change listener using event-driven watching.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    hash::Hasher,
+    sync::{Arc, Mutex},
+};
 
 use async_channel::{Receiver, Sender};
 use clipboard_rs::{
@@ -88,6 +91,48 @@ const fn should_forward_image(last_copy: &LastCopyState, hash: u64) -> bool {
 
 fn should_forward_text(last_copy: &LastCopyState, text: &str) -> bool {
     !matches!(last_copy, LastCopyState::Text(last_text) if last_text == text)
+}
+
+fn write_optional_content(hasher: &mut seahash::SeaHasher, content: Option<&str>) {
+    match content {
+        Some(value) => {
+            hasher.write_u8(1);
+            hasher.write_usize(value.len());
+            hasher.write(value.as_bytes());
+        }
+        None => hasher.write_u8(0),
+    }
+}
+
+fn rich_text_content_hash(plain_text: &str, html: Option<&str>, rtf: Option<&str>) -> u64 {
+    let mut hasher = seahash::SeaHasher::new();
+    hasher.write_usize(plain_text.len());
+    hasher.write(plain_text.as_bytes());
+    write_optional_content(&mut hasher, html);
+    write_optional_content(&mut hasher, rtf);
+    hasher.finish()
+}
+
+fn should_forward_rich_text(
+    last_copy: &LastCopyState,
+    plain_text: &str,
+    html: Option<&str>,
+    rtf: Option<&str>,
+) -> bool {
+    let hash = rich_text_content_hash(plain_text, html, rtf);
+    !matches!(last_copy, LastCopyState::RichText(last_hash) if *last_hash == hash)
+}
+
+fn image_content_hash(image: &DynamicImage) -> u64 {
+    let mut hasher = seahash::SeaHasher::new();
+    hasher.write_u32(image.width());
+    hasher.write_u32(image.height());
+    let color = image.color();
+    hasher.write_u8(color.bytes_per_pixel());
+    hasher.write_u8(u8::from(color.has_alpha()));
+    hasher.write_u8(u8::from(color.has_color()));
+    hasher.write(image.as_bytes());
+    hasher.finish()
 }
 
 const fn should_forward_files(last_copy: &LastCopyState, hash: u64) -> bool {
@@ -208,7 +253,7 @@ impl ClipboardMonitor {
                 }
             }
             ClipboardPayload::Image(dyn_img) => {
-                let hash: u64 = seahash::hash(dyn_img.as_bytes());
+                let hash = image_content_hash(&dyn_img);
                 if !should_forward_image(last_copy, hash) {
                     return None;
                 }
@@ -227,15 +272,21 @@ impl ClipboardMonitor {
                 html,
                 rtf,
             } => {
-                if !should_forward_text(last_copy, &plain_text) {
+                if !should_forward_rich_text(
+                    last_copy,
+                    &plain_text,
+                    html.as_deref(),
+                    rtf.as_deref(),
+                ) {
                     return None;
                 }
+                let hash = rich_text_content_hash(&plain_text, html.as_deref(), rtf.as_deref());
                 match self.tx.try_send(ClipboardEvent::RichText {
-                    plain_text: plain_text.clone(),
+                    plain_text,
                     html,
                     rtf,
                 }) {
-                    Ok(()) => Some(LastCopyState::Text(plain_text)),
+                    Ok(()) => Some(LastCopyState::RichText(hash)),
                     Err(e) => {
                         tracing::warn!(error = %e, "dropping rich text clipboard event (channel full or closed)");
                         None
@@ -358,6 +409,39 @@ mod tests {
     }
 
     #[test]
+    fn test_should_forward_text_when_last_copy_is_rich_text_returns_true() {
+        let last_copy = LastCopyState::RichText(42);
+
+        assert!(should_forward_text(&last_copy, "hello"));
+    }
+
+    #[test]
+    fn test_should_forward_rich_text_when_markup_changes_returns_true() {
+        let first_hash = rich_text_content_hash("hello", Some("<b>hello</b>"), None);
+        let last_copy = LastCopyState::RichText(first_hash);
+
+        assert!(should_forward_rich_text(
+            &last_copy,
+            "hello",
+            Some("<i>hello</i>"),
+            None,
+        ));
+    }
+
+    #[test]
+    fn test_should_forward_rich_text_when_payload_is_unchanged_returns_false() {
+        let hash = rich_text_content_hash("hello", Some("<b>hello</b>"), None);
+        let last_copy = LastCopyState::RichText(hash);
+
+        assert!(!should_forward_rich_text(
+            &last_copy,
+            "hello",
+            Some("<b>hello</b>"),
+            None,
+        ));
+    }
+
+    #[test]
     fn test_should_forward_files_when_same_hash_returns_false() {
         let last_copy = LastCopyState::Files(42);
 
@@ -390,6 +474,23 @@ mod tests {
         let last_copy = LastCopyState::Text("hello".to_string());
 
         assert!(should_forward_image(&last_copy, 42));
+    }
+
+    #[test]
+    fn test_image_content_hash_when_dimensions_differ_returns_different_hashes() {
+        let horizontal = DynamicImage::ImageRgba8(
+            image::ImageBuffer::from_raw(2, 1, vec![1, 2, 3, 4, 5, 6, 7, 8])
+                .expect("valid horizontal image"),
+        );
+        let vertical = DynamicImage::ImageRgba8(
+            image::ImageBuffer::from_raw(1, 2, vec![1, 2, 3, 4, 5, 6, 7, 8])
+                .expect("valid vertical image"),
+        );
+
+        assert_ne!(
+            image_content_hash(&horizontal),
+            image_content_hash(&vertical)
+        );
     }
 
     #[test]

--- a/src/clipboard/writer.rs
+++ b/src/clipboard/writer.rs
@@ -2,7 +2,7 @@ use clipboard_rs::{Clipboard, ClipboardContent, ClipboardContext};
 use gpui::{App, AppContext as _};
 use image::ImageReader;
 
-use super::CopyRequest;
+use super::{ClipboardWriteError, ClipboardWriteResult, CopyRequest};
 
 /// Spawn the single long-lived task that owns the OS [`ClipboardContext`].
 /// All copy operations funnel through the returned channel so we don't pay
@@ -22,16 +22,13 @@ pub(crate) fn start_clipboard_writer(cx: &App) -> async_channel::Sender<CopyRequ
         while let Ok(req) = rx.recv().await {
             match req {
                 CopyRequest::Text { text, completion } => {
-                    set_text(&ctx, text);
-                    notify_completion(completion);
+                    notify_completion(completion, set_text(&ctx, text));
                 }
                 CopyRequest::Image { path, completion } => {
-                    set_image(&ctx, &path);
-                    notify_completion(completion);
+                    notify_completion(completion, set_image(&ctx, &path));
                 }
                 CopyRequest::Files { paths, completion } => {
-                    set_files(&ctx, &paths);
-                    notify_completion(completion);
+                    notify_completion(completion, set_files(&ctx, &paths));
                 }
                 CopyRequest::RichText {
                     plain_text,
@@ -39,8 +36,7 @@ pub(crate) fn start_clipboard_writer(cx: &App) -> async_channel::Sender<CopyRequ
                     rtf,
                     completion,
                 } => {
-                    set_rich_text(&ctx, plain_text, html, rtf);
-                    notify_completion(completion);
+                    notify_completion(completion, set_rich_text(&ctx, plain_text, html, rtf));
                 }
             }
         }
@@ -55,15 +51,24 @@ fn load_image_from_path(path: &str) -> image::ImageResult<image::DynamicImage> {
         .and_then(ImageReader::decode)
 }
 
-fn set_text(ctx: &ClipboardContext, text: String) {
-    if let Err(e) = ctx.set_text(text) {
-        tracing::warn!(error = %e, "failed to set text to clipboard");
-    }
+fn clipboard_error(error: impl std::fmt::Display) -> ClipboardWriteError {
+    ClipboardWriteError::Clipboard(error.to_string())
 }
 
-fn set_image(ctx: &ClipboardContext, path: &str) {
-    let img_res = load_image_from_path(path);
-    if let Ok(img) = img_res {
+fn set_text(ctx: &ClipboardContext, text: String) -> ClipboardWriteResult {
+    ctx.set_text(text).map_err(clipboard_error)
+}
+
+fn load_and_set_image(
+    path: &str,
+    set_image: impl FnOnce(image::DynamicImage) -> ClipboardWriteResult,
+) -> ClipboardWriteResult {
+    let image = load_image_from_path(path)?;
+    set_image(image)
+}
+
+fn set_image(ctx: &ClipboardContext, path: &str) -> ClipboardWriteResult {
+    load_and_set_image(path, |img| {
         #[cfg(target_os = "macos")]
         {
             // `clipboard-rs::set_image` on macOS clears the pasteboard
@@ -71,16 +76,11 @@ fn set_image(ctx: &ClipboardContext, path: &str) {
             // on the empty intermediate state. Pre-encode here and use
             // `set_buffer` to keep clear→write atomic from its POV.
             let mut bytes = Vec::new();
-            if img
-                .write_to(
-                    &mut std::io::Cursor::new(&mut bytes),
-                    image::ImageFormat::Png,
-                )
-                .is_ok()
-                && let Err(e) = ctx.set_buffer("public.png", bytes)
-            {
-                tracing::warn!(error = %e, "failed to set image to clipboard");
-            }
+            img.write_to(
+                &mut std::io::Cursor::new(&mut bytes),
+                image::ImageFormat::Png,
+            )?;
+            ctx.set_buffer("public.png", bytes).map_err(clipboard_error)
         }
 
         #[cfg(not(target_os = "macos"))]
@@ -88,16 +88,14 @@ fn set_image(ctx: &ClipboardContext, path: &str) {
             use clipboard_rs::common::RustImage;
 
             let rust_image = clipboard_rs::RustImageData::from_dynamic_image(img);
-            if let Err(e) = ctx.set_image(rust_image) {
-                tracing::warn!(error = %e, "failed to set image to clipboard");
-            }
+            ctx.set_image(rust_image).map_err(clipboard_error)
         }
-    }
+    })
 }
 
-fn set_files(ctx: &ClipboardContext, paths: &[String]) {
+fn set_files(ctx: &ClipboardContext, paths: &[String]) -> ClipboardWriteResult {
     if paths.is_empty() {
-        return;
+        return Err(ClipboardWriteError::EmptyFileList);
     }
 
     let contents = vec![
@@ -105,15 +103,10 @@ fn set_files(ctx: &ClipboardContext, paths: &[String]) {
         ClipboardContent::Files(paths.to_vec()),
     ];
 
-    if let Err(error) = ctx.set(contents)
-        && let Err(fallback_error) = ctx.set_files(paths.to_vec())
-    {
-        tracing::warn!(
-            error = %error,
-            fallback_error = %fallback_error,
-            "failed to set files to clipboard"
-        );
+    if ctx.set(contents).is_ok() {
+        return Ok(());
     }
+    ctx.set_files(paths.to_vec()).map_err(clipboard_error)
 }
 
 fn set_rich_text(
@@ -121,7 +114,7 @@ fn set_rich_text(
     plain_text: String,
     html: Option<String>,
     rtf: Option<String>,
-) {
+) -> ClipboardWriteResult {
     let mut contents = vec![ClipboardContent::Text(plain_text.clone())];
     if let Some(html_content) = html {
         contents.push(ClipboardContent::Html(html_content));
@@ -130,20 +123,21 @@ fn set_rich_text(
         contents.push(ClipboardContent::Rtf(rtf_content));
     }
 
-    if let Err(error) = ctx.set(contents)
-        && let Err(fallback_error) = ctx.set_text(plain_text)
-    {
-        tracing::warn!(
-            error = %error,
-            fallback_error = %fallback_error,
-            "failed to set rich text to clipboard"
-        );
+    if ctx.set(contents).is_ok() {
+        return Ok(());
     }
+    ctx.set_text(plain_text).map_err(clipboard_error)
 }
 
-fn notify_completion(completion: Option<std::sync::mpsc::Sender<()>>) {
+fn notify_completion(
+    completion: Option<std::sync::mpsc::Sender<ClipboardWriteResult>>,
+    result: ClipboardWriteResult,
+) {
+    if let Err(error) = &result {
+        tracing::warn!(error = %error, "failed to write clipboard content");
+    }
     if let Some(tx) = completion {
-        let _ = tx.send(());
+        let _ = tx.send(result);
     }
 }
 
@@ -176,16 +170,31 @@ mod tests {
     }
 
     #[test]
-    fn test_notify_completion_when_sender_exists_sends_signal() {
+    fn test_set_image_when_file_is_missing_returns_error() {
+        let setter_called = std::cell::Cell::new(false);
+        let result = load_and_set_image("/definitely/missing/image.png", |_| {
+            setter_called.set(true);
+            Ok(())
+        });
+
+        assert!(matches!(result, Err(ClipboardWriteError::Image(_))));
+        assert!(!setter_called.get());
+    }
+
+    #[test]
+    fn test_notify_completion_when_sender_exists_sends_result() {
         let (completion_tx, completion_rx) = mpsc::channel();
 
-        notify_completion(Some(completion_tx));
+        notify_completion(Some(completion_tx), Err(ClipboardWriteError::EmptyFileList));
 
-        assert_eq!(completion_rx.recv_timeout(Duration::from_secs(1)), Ok(()));
+        assert!(matches!(
+            completion_rx.recv_timeout(Duration::from_secs(1)),
+            Ok(Err(ClipboardWriteError::EmptyFileList))
+        ));
     }
 
     #[test]
     fn test_notify_completion_when_sender_missing_returns_without_panic() {
-        notify_completion(None);
+        notify_completion(None, Ok(()));
     }
 }

--- a/src/config/autostart.rs
+++ b/src/config/autostart.rs
@@ -59,7 +59,7 @@ impl AutoStartManager {
     /// Windows registry should execute. macOS uses a Login Item so bundled
     /// builds point at the `.app` directory that System Settings displays.
     /// On Windows we rewrite Scoop's versioned install path back to the
-    /// stable `current` junction — see [`normalise_scoop_path`].
+    /// stable `current` junction — see `normalise_scoop_path`.
     fn get_app_path() -> Result<String, AutoStartError> {
         let exe_path =
             env::current_exe().map_err(|e| AutoStartError::ExecutablePath(e.to_string()))?;
@@ -123,7 +123,7 @@ impl AutoStartManager {
     /// Login Items / registry entries is unnecessary churn and (on
     /// some Linux desktops) racy.
     pub(crate) fn sync_state(&self, enabled: bool) -> Result<(), AutoStartError> {
-        let current_enabled = self.is_enabled().unwrap_or(false);
+        let current_enabled = self.is_enabled()?;
         match autostart_sync_action(enabled, current_enabled) {
             AutoStartSyncAction::None => Ok(()),
             AutoStartSyncAction::Enable => self.enable(),
@@ -212,17 +212,9 @@ fn normalise_scoop_path(path: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use serial_test::serial;
-
     use super::*;
 
-    // These tests touch OS-level auto-launch state (macOS Login Items /
-    // legacy LaunchAgents, Linux `.desktop` entries, Windows registry). Running them in parallel
-    // can race on that shared global state, so they are serialised explicitly
-    // while the rest of the suite runs in parallel.
-
     #[test]
-    #[serial(autostart)]
     fn test_autostart_manager_creation() {
         use crate::constants::APP_NAME;
         let manager = AutoStartManager::new(APP_NAME);
@@ -230,7 +222,6 @@ mod tests {
     }
 
     #[test]
-    #[serial(autostart)]
     #[expect(clippy::unwrap_used)]
     fn test_get_app_path() {
         let path = AutoStartManager::get_app_path();
@@ -287,20 +278,6 @@ mod tests {
             autostart_sync_action(false, true),
             AutoStartSyncAction::Disable,
         );
-    }
-
-    #[test]
-    #[serial(autostart)]
-    fn test_sync_state() {
-        let manager = AutoStartManager::new("RopyTest").expect("Failed to create manager");
-
-        // Try disabling (may fail on some environments); don't make the test brittle
-        let _ = manager.sync_state(false);
-
-        // Verify state if possible
-        if let Ok(enabled) = manager.is_enabled() {
-            assert!(!enabled);
-        }
     }
 
     // Pure-string Scoop normalisation tests — no OS state, safe to run

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,5 +1,10 @@
 #![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
-use std::{cfg_select, path::PathBuf, str::FromStr};
+use std::{
+    cfg_select,
+    io::Write as _,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use gpui::{App, Global, ReadGlobal, SharedString};
 use serde::{Deserialize, Serialize};
@@ -61,14 +66,18 @@ impl Settings {
 
     /// Load settings, layering the on-disk `config.toml` over the
     /// `Default` instance so partial files keep working across upgrades,
-    /// and clamping each value group via [`validate`] so out-of-range
+    /// and clamping each value group via [`Self::validated`] so out-of-range
     /// values on disk can't propagate into the running app.
     pub(crate) fn load() -> Result<Self, SettingsError> {
         let config_dir = Self::config_dir()?;
+        Self::load_from_dir(&config_dir)
+    }
+
+    fn load_from_dir(config_dir: &Path) -> Result<Self, SettingsError> {
         let config_file = config_dir.join("config.toml");
 
-        std::fs::create_dir_all(&config_dir).map_err(|source| SettingsError::Io {
-            path: config_dir.clone(),
+        std::fs::create_dir_all(config_dir).map_err(|source| SettingsError::Io {
+            path: config_dir.to_path_buf(),
             source,
         })?;
 
@@ -96,12 +105,37 @@ impl Settings {
 
     pub(crate) fn save(&self) -> Result<(), SettingsError> {
         let config_file = Self::config_file()?;
-        let toml_string = toml::to_string_pretty(self)?;
+        self.save_to_file(&config_file)
+    }
 
-        std::fs::write(&config_file, toml_string).map_err(|source| SettingsError::Io {
-            path: config_file,
+    fn save_to_file(&self, config_file: &Path) -> Result<(), SettingsError> {
+        let toml_string = toml::to_string_pretty(self)?;
+        let parent = config_file
+            .parent()
+            .ok_or(SettingsError::ConfigDirectoryNotFound)?;
+        std::fs::create_dir_all(parent).map_err(|source| SettingsError::Io {
+            path: parent.to_path_buf(),
             source,
         })?;
+
+        let mut temp_file =
+            tempfile::NamedTempFile::new_in(parent).map_err(|source| SettingsError::Io {
+                path: parent.to_path_buf(),
+                source,
+            })?;
+        temp_file
+            .write_all(toml_string.as_bytes())
+            .and_then(|()| temp_file.as_file().sync_all())
+            .map_err(|source| SettingsError::Io {
+                path: config_file.to_path_buf(),
+                source,
+            })?;
+        temp_file
+            .persist(config_file)
+            .map_err(|error| SettingsError::Io {
+                path: config_file.to_path_buf(),
+                source: error.error,
+            })?;
         Ok(())
     }
 
@@ -202,7 +236,8 @@ pub(crate) struct ConfirmSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub(crate) struct WindowSettings {
-    /// Allowed range is [`MIN_OPACITY_PERCENT`..=`MAX_OPACITY_PERCENT`];
+    /// Allowed range is [`WindowSettings::MIN_OPACITY_PERCENT`] through
+    /// [`WindowSettings::MAX_OPACITY_PERCENT`];
     /// values outside that band are clamped at load time.
     pub opacity_percent: u8,
 }
@@ -230,7 +265,7 @@ impl WindowSettings {
 #[serde(default)]
 pub(crate) struct HotkeySettings {
     /// `+`-separated chord parsed by `global_hotkey` (e.g. `cmd+shift+v`).
-    /// Invalid values are reset to the default by [`validate_hotkey`].
+    /// Invalid values are reset to the default by [`Settings::validate_hotkey`].
     pub activation_key: String,
 }
 
@@ -349,10 +384,32 @@ mod tests {
     }
 
     #[test]
-    fn test_load_settings() {
-        // This should work with default values even if no config file exists
-        let result = Settings::load();
-        assert!(result.is_ok());
+    fn test_load_from_dir_when_config_missing_returns_defaults_without_host_state() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+        let settings = Settings::load_from_dir(temp_dir.path()).expect("Failed to load settings");
+
+        assert_eq!(
+            settings.storage.max_history_records,
+            DEFAULT_MAX_HISTORY_RECORDS
+        );
+        assert!(!temp_dir.path().join("config.toml").exists());
+    }
+
+    #[test]
+    fn test_load_from_dir_when_config_is_invalid_preserves_original_file() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let config_path = temp_dir.path().join("config.toml");
+        let invalid_content = "[storage\nmax_history_records = nope";
+        std::fs::write(&config_path, invalid_content).expect("Failed to write fixture");
+
+        let result = Settings::load_from_dir(temp_dir.path());
+
+        assert!(matches!(result, Err(SettingsError::Deserialize(_))));
+        assert_eq!(
+            std::fs::read_to_string(config_path).expect("Failed to read fixture"),
+            invalid_content
+        );
     }
 
     #[test]
@@ -397,13 +454,10 @@ mod tests {
         settings.layout.mode = LayoutMode::Grid;
         settings.window.opacity_percent = 72;
 
-        // Save to file
-        let toml = toml::to_string_pretty(&settings).expect("Failed to serialize");
-        std::fs::write(&config_path, toml).expect("Failed to write config");
-
-        // Load back
-        let content = std::fs::read_to_string(&config_path).expect("Failed to read config");
-        let loaded: Settings = toml::from_str(&content).expect("Failed to deserialize");
+        settings
+            .save_to_file(&config_path)
+            .expect("Failed to save settings");
+        let loaded = Settings::load_from_dir(temp_dir.path()).expect("Failed to load settings");
 
         // Verify all fields match
         assert_eq!(loaded.storage.max_history_records, 50);

--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -25,6 +25,8 @@ use crate::{
     repository::SharedRecords,
 };
 
+pub(crate) const MAIN_WINDOW_TITLE: &str = "Ropy";
+
 #[derive(RustEmbed)]
 #[folder = "assets"]
 pub(crate) struct Assets;
@@ -64,6 +66,7 @@ pub(crate) fn create_window(
             ..Default::default()
         },
         |window, cx| {
+            window.set_window_title(MAIN_WINDOW_TITLE);
             // Apply the application theme based on settings
             let theme_id = Settings::read(cx, |s| s.theme.clone());
             set_app_theme(window, cx, &theme_id, window_opacity_percent);

--- a/src/gui/board/clipboard_ops.rs
+++ b/src/gui/board/clipboard_ops.rs
@@ -4,7 +4,7 @@ use gpui::{Context, Window};
 
 use super::RopyBoard;
 use crate::{
-    clipboard::{CopyRequest, load_rich_text_html, load_rich_text_rtf},
+    clipboard::{ClipboardWriteResult, CopyRequest, load_rich_text_html, load_rich_text_rtf},
     config::ConfirmMode,
     gui::{hide_window, paste},
     repository::{ClipboardRecord, models::ContentType},
@@ -23,7 +23,7 @@ pub(in crate::gui::board) enum ConfirmFormat {
 pub(in crate::gui::board) fn build_copy_request(
     content: &str,
     content_type: &ContentType,
-    completion: Option<mpsc::Sender<()>>,
+    completion: Option<mpsc::Sender<ClipboardWriteResult>>,
 ) -> Option<CopyRequest> {
     match content_type {
         ContentType::Text => Some(completion.map_or_else(
@@ -56,7 +56,7 @@ pub(in crate::gui::board) fn build_copy_request(
 pub(in crate::gui::board) fn build_copy_request_for_record(
     record: &ClipboardRecord,
     confirm_format: ConfirmFormat,
-    completion: Option<mpsc::Sender<()>>,
+    completion: Option<mpsc::Sender<ClipboardWriteResult>>,
 ) -> Option<CopyRequest> {
     if confirm_format == ConfirmFormat::PlainText && record.content_type == ContentType::RichText {
         return Some(completion.map_or_else(
@@ -77,6 +77,22 @@ pub(in crate::gui::board) fn build_copy_request_for_record(
         Some(tx) => CopyRequest::rich_text_with_completion(record.content.clone(), html, rtf, tx),
         None => CopyRequest::rich_text(record.content.clone(), html, rtf),
     })
+}
+
+pub(in crate::gui::board) fn wait_for_clipboard_write(
+    rx: &mpsc::Receiver<ClipboardWriteResult>,
+) -> bool {
+    match rx.recv_timeout(Duration::from_millis(CLIPBOARD_WRITE_COMPLETION_TIMEOUT_MS)) {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            tracing::warn!(error = %error, "clipboard write failed");
+            false
+        }
+        Err(error) => {
+            tracing::warn!(error = %error, "timed out waiting for clipboard write completion");
+            false
+        }
+    }
 }
 
 impl RopyBoard {
@@ -102,11 +118,8 @@ impl RopyBoard {
                 return false;
             }
             if let Some((_, rx)) = completion
-                && rx
-                    .recv_timeout(Duration::from_millis(CLIPBOARD_WRITE_COMPLETION_TIMEOUT_MS))
-                    .is_err()
+                && !wait_for_clipboard_write(&rx)
             {
-                tracing::warn!("timed out waiting for clipboard write completion");
                 return false;
             }
             return true;

--- a/src/gui/board/records_list/row.rs
+++ b/src/gui/board/records_list/row.rs
@@ -33,6 +33,7 @@ use crate::{
     clipboard::thumb_path_for,
     config::LayoutMode,
     gui::surface_with_opacity,
+    i18n::I18n,
     repository::{ClipboardRecord, SharedRecords, models::ContentType},
     utils::read_or_recover,
 };
@@ -126,14 +127,14 @@ fn render_file_record(cx: &App, record: &ClipboardRecord, compact: bool) -> AnyE
         return div()
             .text_sm()
             .text_color(cx.theme().secondary_foreground)
-            .child("File")
+            .child(I18n::translate(cx, "record_file_empty"))
             .into_any_element();
     }
 
     let title = if files.len() == 1 {
         file_display_name(&files[0])
     } else {
-        format!("{} files", files.len())
+        I18n::translate_count(cx, "record_file_count", files.len())
     };
     let detail = if files.len() == 1 {
         files[0].clone()

--- a/src/gui/board/tests.rs
+++ b/src/gui/board/tests.rs
@@ -8,7 +8,9 @@ use rstest::rstest;
 
 use super::{
     actions::horizontal_grid_target_index,
-    clipboard_ops::{ConfirmFormat, build_copy_request, build_copy_request_for_record},
+    clipboard_ops::{
+        ConfirmFormat, build_copy_request, build_copy_request_for_record, wait_for_clipboard_write,
+    },
     filtering::filter_and_sort_record_indices,
     grid_reveal_offset,
     search::{ContentFilter, SearchOptions},
@@ -16,11 +18,33 @@ use super::{
     settings_editor::UpdateManager,
 };
 use crate::{
+    clipboard::ClipboardWriteError,
     config::{ConfirmMode, LayoutMode},
     gui::board::{RopyBoard, UiState},
     repository::{ClipboardRecord, models::ContentType},
     updater::models::UpdateStatus,
 };
+
+#[test]
+fn test_wait_for_clipboard_write_when_writer_succeeds_returns_true() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    assert!(tx.send(Ok(())).is_ok());
+
+    assert!(wait_for_clipboard_write(&rx));
+}
+
+#[test]
+fn test_wait_for_clipboard_write_when_writer_fails_returns_false() {
+    let (tx, rx) = std::sync::mpsc::channel();
+    assert!(
+        tx.send(Err(ClipboardWriteError::Clipboard(
+            "injected failure".to_string(),
+        )))
+        .is_ok()
+    );
+
+    assert!(!wait_for_clipboard_write(&rx));
+}
 
 #[rstest]
 #[case(false, true)]

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, io, thread, time::Duration};
+use std::{error::Error, io};
 
 use x11rb::{
     connection::Connection,
@@ -6,8 +6,6 @@ use x11rb::{
     rust_connection::RustConnection,
     wrapper::ConnectionExt as _,
 };
-
-const ACTIVE_WINDOW_POLL_INTERVAL_MS: u64 = 10;
 
 pub struct X11 {
     connection: RustConnection,
@@ -134,7 +132,8 @@ impl X11 {
     ///
     /// # Errors
     ///
-    /// Returns an error if the X11 connection fails or the window cannot be displayed/activated.
+    /// Returns an error if the X11 request cannot be sent. Window managers
+    /// are allowed to decline activation requests without reporting an error.
     pub fn display_and_activate_window(&self) -> Result<(), Box<dyn Error>> {
         self.display_window()?;
         self.active_window()?;
@@ -158,7 +157,9 @@ impl X11 {
     ///
     /// # Errors
     ///
-    /// Returns an error if the X11 connection fails or the window cannot be activated.
+    /// Returns an error if the X11 request cannot be sent. The request is
+    /// asynchronous: the window manager may decline it without reporting an
+    /// error to the client.
     pub fn active_window(&self) -> Result<(), Box<dyn Error>> {
         let event = ClientMessageEvent::new(
             32,
@@ -175,7 +176,6 @@ impl X11 {
         )?;
 
         self.connection.sync()?;
-        self.wait_actvate_window()?;
 
         Ok(())
     }
@@ -190,27 +190,5 @@ impl X11 {
         self.connection.sync()?;
 
         Ok(())
-    }
-
-    fn wait_actvate_window(&self) -> Result<(), Box<dyn Error>> {
-        loop {
-            let prop = self
-                .connection
-                .get_property(
-                    false,
-                    self.root_id,
-                    self.net_active_window,
-                    AtomEnum::WINDOW,
-                    0,
-                    1,
-                )?
-                .reply()?;
-
-            if u32::from_ne_bytes(prop.value[0..4].try_into()?) == self.window_id {
-                return Ok(());
-            }
-
-            thread::sleep(Duration::from_millis(ACTIVE_WINDOW_POLL_INTERVAL_MS));
-        }
     }
 }

--- a/src/gui/x11.rs
+++ b/src/gui/x11.rs
@@ -7,6 +7,7 @@ use x11rb::{
     wrapper::ConnectionExt as _,
 };
 
+/// Native X11 window operations for the Ropy application window.
 pub struct X11 {
     connection: RustConnection,
     root_id: u32,

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -17,7 +17,7 @@ pub(crate) use translations::Translations;
 /// I18n manager for handling translations.
 ///
 /// Registered as a GPUI [`Global`] so translations are accessible from any
-/// context via [`I18n::global`] or [`I18n::translate`].
+/// context via [`ReadGlobal::global`] or [`I18n::translate`].
 #[derive(Debug, Clone)]
 pub(crate) struct I18n {
     current_language: Language,
@@ -81,6 +81,11 @@ impl I18n {
         Self::global(cx).t(key)
     }
 
+    /// Translate a message containing a `{count}` placeholder.
+    pub(crate) fn translate_count(cx: &App, key: &str, count: usize) -> String {
+        interpolate_count(&Self::translate(cx, key), count)
+    }
+
     /// Get a reference to the global I18n instance.
     pub(crate) fn load_i18n(language: Language) -> Self {
         Self::new(language).unwrap_or_else(|e| {
@@ -88,6 +93,11 @@ impl I18n {
             Self::default()
         })
     }
+}
+
+fn interpolate_count(template: &str, count: usize) -> String {
+    const COUNT_PLACEHOLDER: &str = concat!("{", "count", "}");
+    template.replace(COUNT_PLACEHOLDER, &count.to_string())
 }
 
 impl Default for I18n {
@@ -184,5 +194,10 @@ mod tests {
         // An unknown locale should fall back to the first available locale
         let i18n = I18n::new(Language::new("xx-UNKNOWN"));
         assert!(i18n.is_ok());
+    }
+
+    #[test]
+    fn test_interpolate_count_replaces_placeholder() {
+        assert_eq!(interpolate_count("{count} files", 3), "3 files");
     }
 }

--- a/src/repository/backend.rs
+++ b/src/repository/backend.rs
@@ -1,6 +1,6 @@
 //! Abstract storage backend trait for the clipboard repository.
 //!
-//! This module defines the [`StorageBackend`] trait that decouples the
+//! This module defines the `StorageBackend` trait that decouples the
 //! repository's business logic from any concrete database implementation.
 //! Production uses `redb`; tests can inject the in-memory backend through
 //! this trait and the repository test helpers.
@@ -8,6 +8,24 @@
 use std::path::PathBuf;
 
 use super::errors::RepositoryError;
+
+pub(super) const META_TREE: &str = "meta";
+pub(super) const RECORDS_TREE: &str = "clipboard_records";
+pub(super) const TIME_INDEX_TREE: &str = "time_index";
+pub(super) const TIME_INDEX_LOOKUP_TREE: &str = "time_index_lookup";
+pub(super) const FAVORITES_TREE: &str = "favorites";
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TreeKey<'a> {
+    pub tree: &'static str,
+    pub key: &'a [u8],
+}
+
+impl<'a> TreeKey<'a> {
+    pub(crate) const fn new(tree: &'static str, key: &'a [u8]) -> Self {
+        Self { tree, key }
+    }
+}
 
 #[cfg(test)]
 pub mod memory;
@@ -26,6 +44,7 @@ pub(crate) trait KvTree: Send + Sync {
 
     fn len(&self) -> usize;
 
+    #[cfg(test)]
     fn clear(&self) -> Result<(), RepositoryError>;
 
     /// Iterate ascending by key. The callback returns `false` to stop early.
@@ -47,6 +66,12 @@ pub(crate) trait StorageBackend: Send + Sync {
     type Tree: KvTree;
 
     fn open_tree(&self, name: &str) -> Result<Self::Tree, RepositoryError>;
+
+    /// Remove keys from multiple logical trees in one atomic transaction.
+    fn remove_batch(&self, removals: &[TreeKey<'_>]) -> Result<Vec<bool>, RepositoryError>;
+
+    /// Clear multiple logical trees in one atomic transaction.
+    fn clear_batch(&self, trees: &[&'static str]) -> Result<(), RepositoryError>;
 
     fn flush(&self) -> Result<(), RepositoryError>;
 }

--- a/src/repository/backend/memory.rs
+++ b/src/repository/backend/memory.rs
@@ -5,22 +5,31 @@
 use std::{
     collections::{BTreeMap, HashMap},
     path::PathBuf,
-    sync::{Arc, LockResult, Mutex, PoisonError, RwLock},
+    sync::{
+        Arc, LockResult, Mutex, PoisonError, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use crate::repository::{
-    backend::{KvTree, StorageBackend},
+    backend::{KvTree, StorageBackend, TreeKey},
     errors::RepositoryError,
 };
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct MemoryBackend {
-    trees: Mutex<HashMap<String, Arc<MemoryTree>>>,
+    trees: Arc<Mutex<HashMap<String, Arc<MemoryTree>>>>,
+    transaction_lock: Arc<Mutex<()>>,
+    fail_next_batch: Arc<AtomicBool>,
 }
 
 impl MemoryBackend {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    pub(crate) fn fail_next_batch(&self) {
+        self.fail_next_batch.store(true, Ordering::SeqCst);
     }
 }
 
@@ -38,7 +47,48 @@ impl StorageBackend for MemoryBackend {
             .entry(name.to_string())
             .or_insert_with(|| Arc::new(MemoryTree::default()))
             .clone();
-        Ok(MemoryTreeHandle(tree))
+        Ok(MemoryTreeHandle {
+            tree,
+            transaction_lock: self.transaction_lock.clone(),
+        })
+    }
+
+    fn remove_batch(&self, removals: &[TreeKey<'_>]) -> Result<Vec<bool>, RepositoryError> {
+        let _transaction = recover_lock(self.transaction_lock.lock());
+        if self.fail_next_batch.swap(false, Ordering::SeqCst) {
+            return Err(RepositoryError::Delete(
+                "injected batch deletion failure".to_string(),
+            ));
+        }
+
+        let trees = recover_lock(self.trees.lock());
+        let mut results = Vec::with_capacity(removals.len());
+        for removal in removals {
+            let removed = trees.get(removal.tree).is_some_and(|tree| {
+                recover_lock(tree.entries.write())
+                    .remove(removal.key)
+                    .is_some()
+            });
+            results.push(removed);
+        }
+        Ok(results)
+    }
+
+    fn clear_batch(&self, tree_names: &[&'static str]) -> Result<(), RepositoryError> {
+        let _transaction = recover_lock(self.transaction_lock.lock());
+        if self.fail_next_batch.swap(false, Ordering::SeqCst) {
+            return Err(RepositoryError::Delete(
+                "injected batch deletion failure".to_string(),
+            ));
+        }
+
+        let trees = recover_lock(self.trees.lock());
+        for tree_name in tree_names {
+            if let Some(tree) = trees.get(*tree_name) {
+                recover_lock(tree.entries.write()).clear();
+            }
+        }
+        Ok(())
     }
 
     fn flush(&self) -> Result<(), RepositoryError> {
@@ -57,36 +107,43 @@ struct MemoryTree {
 }
 
 #[derive(Clone)]
-pub(crate) struct MemoryTreeHandle(Arc<MemoryTree>);
+pub(crate) struct MemoryTreeHandle {
+    tree: Arc<MemoryTree>,
+    transaction_lock: Arc<Mutex<()>>,
+}
 
 impl KvTree for MemoryTreeHandle {
     fn insert(&self, key: &[u8], value: &[u8]) -> Result<(), RepositoryError> {
-        let entries_lock = self.0.entries.write();
+        let _transaction = recover_lock(self.transaction_lock.lock());
+        let entries_lock = self.tree.entries.write();
         let mut entries = recover_lock(entries_lock);
         entries.insert(key.to_vec(), value.to_vec());
         Ok(())
     }
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RepositoryError> {
-        let entries_lock = self.0.entries.read();
+        let entries_lock = self.tree.entries.read();
         let entries = recover_lock(entries_lock);
         Ok(entries.get(key).cloned())
     }
 
     fn remove(&self, key: &[u8]) -> Result<bool, RepositoryError> {
-        let entries_lock = self.0.entries.write();
+        let _transaction = recover_lock(self.transaction_lock.lock());
+        let entries_lock = self.tree.entries.write();
         let mut entries = recover_lock(entries_lock);
         Ok(entries.remove(key).is_some())
     }
 
     fn len(&self) -> usize {
-        let entries_lock = self.0.entries.read();
+        let entries_lock = self.tree.entries.read();
         let entries = recover_lock(entries_lock);
         entries.len()
     }
 
+    #[cfg(test)]
     fn clear(&self) -> Result<(), RepositoryError> {
-        let entries_lock = self.0.entries.write();
+        let _transaction = recover_lock(self.transaction_lock.lock());
+        let entries_lock = self.tree.entries.write();
         let mut entries = recover_lock(entries_lock);
         entries.clear();
         Ok(())
@@ -96,7 +153,7 @@ impl KvTree for MemoryTreeHandle {
         &self,
         callback: &mut dyn FnMut(&[u8], &[u8]) -> bool,
     ) -> Result<(), RepositoryError> {
-        let entries_lock = self.0.entries.read();
+        let entries_lock = self.tree.entries.read();
         let entries = recover_lock(entries_lock);
         for (key, value) in entries.iter() {
             if !callback(key, value) {
@@ -110,7 +167,7 @@ impl KvTree for MemoryTreeHandle {
         &self,
         callback: &mut dyn FnMut(&[u8], &[u8]) -> bool,
     ) -> Result<(), RepositoryError> {
-        let entries_lock = self.0.entries.read();
+        let entries_lock = self.tree.entries.read();
         let entries = recover_lock(entries_lock);
         for (key, value) in entries.iter().rev() {
             if !callback(key, value) {

--- a/src/repository/backend/redb.rs
+++ b/src/repository/backend/redb.rs
@@ -7,16 +7,13 @@
 use std::{
     fs,
     path::PathBuf,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::{Arc, Mutex},
 };
 
 use redb::{Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition};
 
 use crate::repository::{
-    backend::{KvTree, StorageBackend},
+    backend::{KvTree, StorageBackend, TreeKey},
     errors::RepositoryError,
 };
 
@@ -55,6 +52,48 @@ impl StorageBackend for RedbBackend {
         RedbTree::open(self.db.clone(), name.to_string())
     }
 
+    fn remove_batch(&self, removals: &[TreeKey<'_>]) -> Result<Vec<bool>, RepositoryError> {
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| RepositoryError::Delete(error.to_string()))?;
+        let mut results = Vec::with_capacity(removals.len());
+        for removal in removals {
+            let removed = {
+                let mut table = write_txn
+                    .open_table(RedbTree::table_definition(removal.tree))
+                    .map_err(|error| RepositoryError::Delete(error.to_string()))?;
+                table
+                    .remove(removal.key)
+                    .map_err(|error| RepositoryError::Delete(error.to_string()))?
+                    .is_some()
+            };
+            results.push(removed);
+        }
+        write_txn
+            .commit()
+            .map_err(|error| RepositoryError::Delete(error.to_string()))?;
+        Ok(results)
+    }
+
+    fn clear_batch(&self, trees: &[&'static str]) -> Result<(), RepositoryError> {
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| RepositoryError::Delete(error.to_string()))?;
+        for tree_name in trees {
+            let mut table = write_txn
+                .open_table(RedbTree::table_definition(tree_name))
+                .map_err(|error| RepositoryError::Delete(error.to_string()))?;
+            table
+                .retain(|_, _| false)
+                .map_err(|error| RepositoryError::Delete(error.to_string()))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|error| RepositoryError::Delete(error.to_string()))
+    }
+
     fn flush(&self) -> Result<(), RepositoryError> {
         // redb writes are durably committed per transaction by default.
         Ok(())
@@ -69,7 +108,6 @@ pub(crate) fn redb_backend_factory(db_path: &PathBuf) -> Result<RedbBackend, Rep
 pub(crate) struct RedbTree {
     db: Arc<Database>,
     name: String,
-    len: Arc<AtomicUsize>,
     write_lock: Mutex<()>,
 }
 
@@ -78,15 +116,14 @@ impl RedbTree {
         let write_txn = db
             .begin_write()
             .map_err(|error| RepositoryError::TreeOpen(error.to_string()))?;
-        let len = {
+        {
             let table = write_txn
                 .open_table(Self::table_definition(&name))
                 .map_err(|error| RepositoryError::TreeOpen(error.to_string()))?;
-            let len = table
+            table
                 .len()
                 .map_err(|error| RepositoryError::TreeOpen(error.to_string()))?;
-            usize::try_from(len).unwrap_or(usize::MAX)
-        };
+        }
         write_txn
             .commit()
             .map_err(|error| RepositoryError::TreeOpen(error.to_string()))?;
@@ -94,7 +131,6 @@ impl RedbTree {
         Ok(Self {
             db,
             name,
-            len: Arc::new(AtomicUsize::new(len)),
             write_lock: Mutex::new(()),
         })
     }
@@ -149,16 +185,12 @@ impl RedbTree {
 
 impl KvTree for RedbTree {
     fn insert(&self, key: &[u8], value: &[u8]) -> Result<(), RepositoryError> {
-        let existed = self.with_write_table(RepositoryError::Insert, |table| {
+        self.with_write_table(RepositoryError::Insert, |table| {
             let replaced = table
                 .insert(key, value)
                 .map_err(|error| RepositoryError::Insert(error.to_string()))?;
             Ok(replaced.is_some())
         })?;
-
-        if !existed {
-            self.len.fetch_add(1, Ordering::Relaxed);
-        }
         Ok(())
     }
 
@@ -179,16 +211,23 @@ impl KvTree for RedbTree {
             Ok(removed.is_some())
         })?;
 
-        if removed {
-            self.len.fetch_sub(1, Ordering::Relaxed);
-        }
         Ok(removed)
     }
 
     fn len(&self) -> usize {
-        self.len.load(Ordering::Relaxed)
+        self.with_read_table(|table| {
+            table
+                .len()
+                .map(|len| usize::try_from(len).unwrap_or(usize::MAX))
+                .map_err(|error| RepositoryError::Query(error.to_string()))
+        })
+        .unwrap_or_else(|error| {
+            tracing::warn!(error = %error, tree = %self.name, "failed to read tree length");
+            0
+        })
     }
 
+    #[cfg(test)]
     fn clear(&self) -> Result<(), RepositoryError> {
         self.with_write_table(RepositoryError::Delete, |table| {
             table
@@ -196,7 +235,6 @@ impl KvTree for RedbTree {
                 .map_err(|error| RepositoryError::Delete(error.to_string()))?;
             Ok(())
         })?;
-        self.len.store(0, Ordering::Relaxed);
         Ok(())
     }
 

--- a/src/repository/cleanup.rs
+++ b/src/repository/cleanup.rs
@@ -4,7 +4,10 @@
 use std::collections::HashSet;
 
 use super::{
-    backend::{KvTree, StorageBackend, redb::RedbBackend},
+    backend::{
+        RECORDS_TREE, StorageBackend, TIME_INDEX_LOOKUP_TREE, TIME_INDEX_TREE, TreeKey,
+        redb::RedbBackend,
+    },
     errors::RepositoryError,
     models::ClipboardRecord,
     repo::ClipboardRepository,
@@ -89,13 +92,17 @@ impl<B: StorageBackend> ClipboardRepository<B> {
             }
 
             let rec_key = id.to_be_bytes();
-            if let Some(value) = self.get_raw(&rec_key)?
-                && let Ok(record) = postcard::from_bytes::<ClipboardRecord>(&value)
-            {
-                remove_record_sidecars(&record);
+            let record = self
+                .get_raw(&rec_key)?
+                .and_then(|value| postcard::from_bytes::<ClipboardRecord>(&value).ok());
+            self.backend.remove_batch(&[
+                TreeKey::new(RECORDS_TREE, &rec_key),
+                TreeKey::new(TIME_INDEX_TREE, &ti_key),
+                TreeKey::new(TIME_INDEX_LOOKUP_TREE, &rec_key),
+            ])?;
+            if let Some(record) = record.as_ref() {
+                remove_record_sidecars(record);
             }
-            self.records.remove(&rec_key)?;
-            self.time_index.remove_raw(&ti_key)?;
             removed += 1;
         }
         Ok(removed)

--- a/src/repository/favorites.rs
+++ b/src/repository/favorites.rs
@@ -45,6 +45,7 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         Ok(true)
     }
 
+    #[cfg(test)]
     pub(super) fn remove_favorite(&self, id: u64) -> Result<(), RepositoryError> {
         self.favorites.remove(&id.to_be_bytes())?;
         Ok(())

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -7,7 +7,8 @@ use chrono::Local;
 
 use super::{
     backend::{
-        BackendFactory, KvTree, StorageBackend,
+        BackendFactory, FAVORITES_TREE, KvTree, META_TREE, RECORDS_TREE, StorageBackend,
+        TIME_INDEX_LOOKUP_TREE, TIME_INDEX_TREE, TreeKey,
         redb::{RedbBackend, redb_backend_factory},
     },
     errors::RepositoryError,
@@ -28,7 +29,7 @@ use crate::{
 const SCHEMA_VERSION: u64 = 3;
 
 pub(crate) struct ClipboardRepository<B: StorageBackend = RedbBackend> {
-    backend: B,
+    pub(super) backend: B,
     pub(super) records: B::Tree,
     pub(super) time_index: TimeIndex<B::Tree>,
     pub(super) favorites: B::Tree,
@@ -67,13 +68,13 @@ impl<B: StorageBackend> ClipboardRepository<B> {
     }
 
     pub(crate) fn from_backend(backend: B, images_dir: PathBuf) -> Result<Self, RepositoryError> {
-        let meta = backend.open_tree("meta")?;
-        let records = backend.open_tree("clipboard_records")?;
+        let meta = backend.open_tree(META_TREE)?;
+        let records = backend.open_tree(RECORDS_TREE)?;
         let time_index = TimeIndex::new(
-            backend.open_tree("time_index")?,
-            backend.open_tree("time_index_lookup")?,
+            backend.open_tree(TIME_INDEX_TREE)?,
+            backend.open_tree(TIME_INDEX_LOOKUP_TREE)?,
         );
-        let favorites = backend.open_tree("favorites")?;
+        let favorites = backend.open_tree(FAVORITES_TREE)?;
 
         let rich_text_dir = images_dir.parent().map_or_else(
             || PathBuf::from("rich_text"),
@@ -81,9 +82,12 @@ impl<B: StorageBackend> ClipboardRepository<B> {
         );
 
         if Self::needs_schema_migration(&meta)? {
-            records.clear()?;
-            time_index.clear()?;
-            favorites.clear()?;
+            backend.clear_batch(&[
+                RECORDS_TREE,
+                TIME_INDEX_TREE,
+                TIME_INDEX_LOOKUP_TREE,
+                FAVORITES_TREE,
+            ])?;
             purge_sidecar_dirs(&images_dir, &rich_text_dir);
             meta.insert(b"schema_version", &SCHEMA_VERSION.to_be_bytes())?;
             backend.flush()?;
@@ -290,26 +294,39 @@ impl<B: StorageBackend> ClipboardRepository<B> {
 
     pub(crate) fn delete(&self, id: u64) -> Result<bool, RepositoryError> {
         let record = self.get_by_id(id)?;
-        if let Some(ref rec) = record {
-            remove_record_sidecars(rec);
-        }
-
         let key = id.to_be_bytes();
-        let removed = self.records.remove(&key)?;
-        self.remove_favorite(id)?;
+        let time_key = record.as_ref().map(|record| {
+            TimeIndex::<B::Tree>::encode_key(record.created_at.timestamp_millis(), id)
+        });
+        let mut removals = vec![
+            TreeKey::new(RECORDS_TREE, &key),
+            TreeKey::new(FAVORITES_TREE, &key),
+        ];
+        if let Some(time_key) = time_key.as_ref() {
+            removals.push(TreeKey::new(TIME_INDEX_TREE, time_key));
+            removals.push(TreeKey::new(TIME_INDEX_LOOKUP_TREE, &key));
+        }
+        let removed = self
+            .backend
+            .remove_batch(&removals)?
+            .first()
+            .copied()
+            .unwrap_or(false);
 
-        if let Some(rec) = record {
-            self.time_index
-                .remove(rec.created_at.timestamp_millis(), rec.id)?;
+        if removed && let Some(record) = record.as_ref() {
+            remove_record_sidecars(record);
         }
         Ok(removed)
     }
 
     /// Wipe every record and its on-disk sidecars (images + rich text).
     pub(crate) fn clear(&self) -> Result<(), RepositoryError> {
-        self.records.clear()?;
-        self.time_index.clear()?;
-        self.favorites.clear()?;
+        self.backend.clear_batch(&[
+            RECORDS_TREE,
+            TIME_INDEX_TREE,
+            TIME_INDEX_LOOKUP_TREE,
+            FAVORITES_TREE,
+        ])?;
         purge_sidecar_dirs(&self.images_dir, &self.rich_text_dir);
         Ok(())
     }

--- a/src/repository/tests/dedup_tests.rs
+++ b/src/repository/tests/dedup_tests.rs
@@ -7,13 +7,27 @@ use rstest::rstest;
 
 use crate::repository::{
     backend::{
-        BackendFactory, StorageBackend, memory::memory_backend_factory, redb::redb_backend_factory,
+        BackendFactory, StorageBackend,
+        memory::{MemoryBackend, memory_backend_factory},
+        redb::redb_backend_factory,
     },
     repo::ClipboardRepository,
     test_helpers::{
         create_test_repo, create_test_repo_with, load_display_records, save_numbered_records,
     },
 };
+
+fn create_failure_injecting_repo() -> (
+    tempfile::TempDir,
+    MemoryBackend,
+    ClipboardRepository<MemoryBackend>,
+) {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let backend = MemoryBackend::new();
+    let repo = ClipboardRepository::from_backend(backend.clone(), temp_dir.path().join("images"))
+        .expect("Failed to create repository");
+    (temp_dir, backend, repo)
+}
 
 #[test]
 fn test_dedup_same_content() {
@@ -295,6 +309,56 @@ fn test_delete_when_record_is_rich_text_removes_sidecar_files() {
 }
 
 #[test]
+fn test_delete_when_database_batch_fails_preserves_record_and_sidecars() {
+    let (_temp_dir, backend, repo) = create_failure_injecting_repo();
+    let record = repo
+        .save_rich_text("hello".to_string(), Some("<p>hello</p>"), None)
+        .expect("Failed to save rich text");
+    let html_path = record
+        .rich_text_meta
+        .as_ref()
+        .and_then(|meta| meta.html_path.as_ref())
+        .expect("HTML path should be present")
+        .clone();
+    backend.fail_next_batch();
+
+    let result = repo.delete(record.id);
+
+    assert!(result.is_err());
+    assert!(
+        repo.get_by_id(record.id)
+            .expect("Failed to query")
+            .is_some()
+    );
+    assert!(std::path::Path::new(&html_path).exists());
+}
+
+#[test]
+fn test_cleanup_when_database_batch_fails_preserves_record_and_sidecars() {
+    let (_temp_dir, backend, repo) = create_failure_injecting_repo();
+    let record = repo
+        .save_rich_text("hello".to_string(), Some("<p>hello</p>"), None)
+        .expect("Failed to save rich text");
+    let html_path = record
+        .rich_text_meta
+        .as_ref()
+        .and_then(|meta| meta.html_path.as_ref())
+        .expect("HTML path should be present")
+        .clone();
+    backend.fail_next_batch();
+
+    let result = repo.cleanup_old_records(0);
+
+    assert!(result.is_err());
+    assert!(
+        repo.get_by_id(record.id)
+            .expect("Failed to query")
+            .is_some()
+    );
+    assert!(std::path::Path::new(&html_path).exists());
+}
+
+#[test]
 fn test_delete_nonexistent() {
     let repo = create_test_repo();
 
@@ -313,6 +377,31 @@ fn test_clear() {
 
     repo.clear().expect("Failed to clear");
     assert_eq!(repo.count(), 0);
+}
+
+#[test]
+fn test_clear_when_database_batch_fails_preserves_records_and_sidecars() {
+    let (_temp_dir, backend, repo) = create_failure_injecting_repo();
+    let record = repo
+        .save_rich_text("hello".to_string(), Some("<p>hello</p>"), None)
+        .expect("Failed to save rich text");
+    let html_path = record
+        .rich_text_meta
+        .as_ref()
+        .and_then(|meta| meta.html_path.as_ref())
+        .expect("HTML path should be present")
+        .clone();
+    backend.fail_next_batch();
+
+    let result = repo.clear();
+
+    assert!(result.is_err());
+    assert!(
+        repo.get_by_id(record.id)
+            .expect("Failed to query")
+            .is_some()
+    );
+    assert!(std::path::Path::new(&html_path).exists());
 }
 
 #[test]

--- a/src/repository/time_index.rs
+++ b/src/repository/time_index.rs
@@ -54,6 +54,7 @@ impl<T: KvTree> TimeIndex<T> {
     }
 
     /// Remove the entry that matches the given `(timestamp_millis, id)` pair.
+    #[cfg(test)]
     pub(super) fn remove(&self, timestamp_millis: i64, id: u64) -> Result<(), RepositoryError> {
         let key = Self::encode_key(timestamp_millis, id);
         self.entries.remove(&key)?;
@@ -75,6 +76,7 @@ impl<T: KvTree> TimeIndex<T> {
     }
 
     /// Clear all entries.
+    #[cfg(test)]
     pub(super) fn clear(&self) -> Result<(), RepositoryError> {
         self.entries.clear()?;
         self.id_lookup.clear()
@@ -206,6 +208,7 @@ impl<T: KvTree> TimeIndex<T> {
     }
 
     /// Delete a raw encoded key from the underlying tree.
+    #[cfg(test)]
     pub(super) fn remove_raw(&self, key: &[u8; 16]) -> Result<(), RepositoryError> {
         self.entries.remove(key.as_ref())?;
         let id = u64::from_be_bytes(key[8..].try_into().unwrap_or_default());

--- a/src/updater/checker.rs
+++ b/src/updater/checker.rs
@@ -65,11 +65,12 @@ fn resolve_release(
         .find(|a| a.name == asset_name)
         .ok_or_else(|| UpdateError::NoCompatibleAsset(target.to_string()))?;
 
-    let checksum_asset = release.assets.iter().find(|a| a.name == checksum_name);
-
-    let checksum_url = checksum_asset
+    let checksum_url = release
+        .assets
+        .iter()
+        .find(|a| a.name == checksum_name)
         .map(|a| a.browser_download_url.clone())
-        .unwrap_or_default();
+        .ok_or(UpdateError::MissingChecksumAsset(checksum_name))?;
 
     Ok(Some(ReleaseInfo {
         version: latest_version.to_string(),
@@ -206,6 +207,26 @@ mod tests {
         assert_eq!(info.asset_size, 4096);
         assert!(info.download_url.ends_with(".tar.xz"));
         assert!(info.checksum_url.ends_with(".tar.xz.sha256"));
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_resolve_release_when_checksum_asset_missing_returns_error() {
+        let release: GitHubRelease = serde_json::from_str(
+            r#"{
+                "tag_name": "0.6.0",
+                "assets": [{
+                    "name": "ropy-aarch64-apple-darwin.tar.xz",
+                    "browser_download_url": "https://example.com/ropy.tar.xz",
+                    "size": 4096
+                }]
+            }"#,
+        )
+        .unwrap();
+
+        let result = resolve_release(release, &Version::new(0, 5, 4), "aarch64-apple-darwin");
+
+        assert!(matches!(result, Err(UpdateError::MissingChecksumAsset(_))));
     }
 
     // ── parse_version Error Cases ─────────────────────────────────

--- a/src/updater/downloader.rs
+++ b/src/updater/downloader.rs
@@ -20,6 +20,7 @@ pub(crate) fn download_and_install(
     release: &ReleaseInfo,
     progress_tx: &async_channel::Sender<f32>,
 ) -> Result<(), UpdateError> {
+    let checksum_url = required_checksum_url(release)?;
     let tmp_dir = tempfile::tempdir().map_err(UpdateError::Io)?;
     let asset_name = release
         .download_url
@@ -37,13 +38,9 @@ pub(crate) fn download_and_install(
         progress_tx,
     )?;
 
-    // 2. Verify checksum (if available)
-    if release.checksum_url.is_empty() {
-        tracing::warn!("no checksum URL provided – skipping verification");
-    } else {
-        tracing::info!("verifying checksum");
-        verify_checksum(&asset_path, &release.checksum_url)?;
-    }
+    // 2. Verify checksum before extracting executable content.
+    tracing::info!("verifying checksum");
+    verify_checksum(&asset_path, checksum_url)?;
 
     // 3. Extract the binary from the archive
     tracing::info!("extracting binary from archive");
@@ -64,6 +61,16 @@ pub(crate) fn download_and_install(
 
     tracing::info!("update installed successfully – restart required");
     Ok(())
+}
+
+fn required_checksum_url(release: &ReleaseInfo) -> Result<&str, UpdateError> {
+    if release.checksum_url.trim().is_empty() {
+        return Err(UpdateError::MissingChecksumAsset(format!(
+            "release {}",
+            release.version
+        )));
+    }
+    Ok(&release.checksum_url)
 }
 
 /// Download `url` into `dest`, reporting progress via `progress_tx`.
@@ -142,11 +149,7 @@ fn verify_checksum(asset_path: &Path, checksum_url: &str) -> Result<(), UpdateEr
         .execute_to_string()?;
 
     // The checksum file format from cargo-dist is:  "<hex>  <filename>\n"
-    let expected_hex = checksum_body
-        .split_whitespace()
-        .next()
-        .unwrap_or("")
-        .to_lowercase();
+    let expected_hex = parse_checksum(&checksum_body)?;
 
     let actual_hex = compute_sha256_hex(asset_path)?;
 
@@ -157,6 +160,16 @@ fn verify_checksum(asset_path: &Path, checksum_url: &str) -> Result<(), UpdateEr
         });
     }
     Ok(())
+}
+
+fn parse_checksum(checksum_body: &str) -> Result<String, UpdateError> {
+    let checksum = checksum_body.split_whitespace().next().unwrap_or("");
+    if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(UpdateError::InvalidChecksum(
+            "expected exactly 64 hexadecimal characters".to_string(),
+        ));
+    }
+    Ok(checksum.to_ascii_lowercase())
 }
 
 fn compute_sha256_hex(asset_path: &Path) -> Result<String, UpdateError> {
@@ -278,12 +291,44 @@ mod tests {
     use super::*;
 
     #[test]
-    #[expect(clippy::unwrap_used)]
-    fn test_verify_checksum_format_parsing() {
-        // Simulate a cargo-dist style checksum line
-        let line = "abcdef1234567890  ropy-aarch64-apple-darwin.tar.xz\n";
-        let expected = line.split_whitespace().next().unwrap().to_lowercase();
-        assert_eq!(expected, "abcdef1234567890");
+    #[expect(clippy::expect_used)]
+    fn test_parse_checksum_when_valid_returns_normalized_hash() {
+        let checksum =
+            "A948904F2F0F479B8F8197694B30184B0D2ED1C1CD2A1EC0FB85D299A192A447  ropy.tar.xz\n";
+
+        let parsed = parse_checksum(checksum).expect("checksum should parse");
+
+        assert_eq!(
+            parsed,
+            "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"
+        );
+    }
+
+    #[rstest::rstest]
+    #[case("")]
+    #[case("abcdef")]
+    #[case("z948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447")]
+    fn test_parse_checksum_when_malformed_returns_error(#[case] checksum: &str) {
+        assert!(matches!(
+            parse_checksum(checksum),
+            Err(UpdateError::InvalidChecksum(_))
+        ));
+    }
+
+    #[test]
+    fn test_required_checksum_url_when_missing_returns_error_before_download() {
+        let release = ReleaseInfo {
+            version: "0.6.0".to_string(),
+            release_notes: String::new(),
+            download_url: "https://example.com/ropy.tar.xz".to_string(),
+            checksum_url: String::new(),
+            asset_size: 1,
+        };
+
+        assert!(matches!(
+            required_checksum_url(&release),
+            Err(UpdateError::MissingChecksumAsset(_))
+        ));
     }
 
     #[test]

--- a/src/updater/errors.rs
+++ b/src/updater/errors.rs
@@ -16,6 +16,12 @@ pub(crate) enum UpdateError {
     #[error("no compatible asset found for target: {0}")]
     NoCompatibleAsset(String),
 
+    #[error("release is missing checksum asset: {0}")]
+    MissingChecksumAsset(String),
+
+    #[error("invalid checksum file: {0}")]
+    InvalidChecksum(String),
+
     #[error("checksum verification failed (expected {expected}, got {actual})")]
     ChecksumMismatch { expected: String, actual: String },
 

--- a/src/utils/single_instance.rs
+++ b/src/utils/single_instance.rs
@@ -6,6 +6,8 @@ use windows_sys::Win32::{
     UI::WindowsAndMessaging::{FindWindowW, SW_RESTORE, SetForegroundWindow, ShowWindow},
 };
 
+use crate::gui::app::MAIN_WINDOW_TITLE;
+
 pub fn ensure_single_instance() -> bool {
     let mutex_name = "RopySingleInstanceMutex";
     let wide_name: Vec<u16> = OsStr::new(mutex_name)
@@ -24,14 +26,18 @@ pub fn ensure_single_instance() -> bool {
         }
 
         if GetLastError() == ERROR_ALREADY_EXISTS {
-            // GPUI registers its Win32 windows under the `Zed::Window`
-            // class name; matching that lets us bring the existing
-            // instance to the foreground instead of silently exiting.
+            // GPUI's class name is shared by every GPUI application. Match
+            // Ropy's native window title as well so another GPUI process is
+            // never activated by mistake.
             let class_name = OsStr::new("Zed::Window")
                 .encode_wide()
                 .chain(std::iter::once(0))
                 .collect::<Vec<_>>();
-            let hwnd = FindWindowW(class_name.as_ptr(), std::ptr::null());
+            let window_title = OsStr::new(MAIN_WINDOW_TITLE)
+                .encode_wide()
+                .chain(std::iter::once(0))
+                .collect::<Vec<_>>();
+            let hwnd = FindWindowW(class_name.as_ptr(), window_title.as_ptr());
             if !hwnd.is_null() {
                 ShowWindow(hwnd, SW_RESTORE);
                 SetForegroundWindow(hwnd);


### PR DESCRIPTION
## Summary

Resolves every actionable finding from the repository-wide code, comment, and test-quality audit. The changes harden clipboard writes, platform activation, repository deletion, updater integrity, settings persistence, localization, documentation, and test isolation.

## Linked Issue

Closes #157

## Changes

- Propagate clipboard write failures, distinguish rich-text payloads, and hash complete image identity.
- Make repository deletion/cleanup/clear atomic across trees and defer sidecar removal until commit succeeds.
- Remove unbounded X11 activation polling and identify the Ropy window specifically on Windows.
- Require valid update checksums in manifests and downloads; save settings atomically without overwriting malformed configuration.
- Isolate settings/autostart tests, localize file labels, and enforce warning-free Rustdoc in precheck.

## Testing

- [x] `scripts/precheck.sh` passes locally
- [x] New / updated tests cover the change
- [x] 471 tests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` passes
- [x] Update manifest generation rejects missing checksums and accepts complete archive/checksum pairs

## Self-Check

- [x] PR title follows Conventional Commits
- [x] No hardcoded user-facing strings — i18n keys added to all locale files
- [x] Errors defined with `thiserror` (no manual `impl Display/Error`)
- [x] No unrelated changes mixed in
