### PR TITLE
chore(config): ignore local Codex MCP credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 .DS_Store
+
+# Local Codex configuration can contain MCP credentials.
+/.codex/config.toml


### PR DESCRIPTION
## Summary

Ignore the project-local Codex MCP configuration so AgentBay credentials cannot be committed accidentally.

## Linked Issue

Closes #165

## Changes

- Add `/.codex/config.toml` to `.gitignore`.
- Keep the actual Linux and Windows AgentBay MCP configuration local to the ropy workspace.

## Testing

- `./scripts/precheck.sh`
- `git check-ignore -v .codex/config.toml`
- `codex mcp list` (verified `agentbay_linux` and `agentbay_windows` are enabled; credentials redacted from output)

## Self-Check

- [x] No MCP URL or API key is included in the commit.
- [x] The ignored local configuration is recognized by Codex.
- [x] Repository precheck passes.
